### PR TITLE
Enabling non-breaking introduction of new supplemental data sections.

### DIFF
--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/SupplementalDataDeserializerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/SupplementalDataDeserializerTests.cs
@@ -132,14 +132,6 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
 
             Func<IIdentifiable> createUser = EntityTypeMapper.GetTypeCreator("users");
             Assert.IsInstanceOfType(createUser(), typeof(User), $"Expected instance of {nameof(User)}");
-
-            try
-            {
-                EntityTypeMapper.GetTypeCreator("none");
-                Assert.Fail("Expected InvalidOperationException to be thrown.");
-            }
-            catch (InvalidOperationException)
-            { }
         }
 
         private static string ResponseContent => @"

--- a/Intuit.TSheets.Tests/Unit/Client/Utilities/EntityTypeMapperTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/Utilities/EntityTypeMapperTests.cs
@@ -44,10 +44,12 @@ namespace Intuit.TSheets.Tests.Unit.Client.Utilities
         }
 
         [TestMethod, TestCategory("Unit")]
-        [ExpectedException(typeof(InvalidOperationException))]
-        public void EntityTypeMapper_ThrowsWhenProvidedInvalidEntityName()
+        public void EntityTypeMapper_ReturnsNullWhenProvidedUnknownEntityName()
         {
-            EntityTypeMapper.GetTypeCreator("notexists");
+            // Mapper must return null for unknown supplemental data sections, so as
+            // not to break existing clients when new sections are added to the API.
+            Func<IIdentifiable> createUnknown = EntityTypeMapper.GetTypeCreator("unknown");
+            Assert.IsNull(createUnknown);
         }
     }
 }

--- a/Intuit.TSheets/Client/Utilities/EntityTypeMapper.cs
+++ b/Intuit.TSheets/Client/Utilities/EntityTypeMapper.cs
@@ -48,15 +48,15 @@ namespace Intuit.TSheets.Client.Utilities
         /// Given an entity name, returns a function that instantiates the type.
         /// </summary>
         /// <param name="entityName">The name of the entity type</param>
-        /// <returns>A function which creates a new instance of the entity type.</returns>
+        /// <returns>
+        /// A function which creates a new instance of the entity type
+        /// if the type is known, else null.
+        /// </returns>
         internal static Func<IIdentifiable> GetTypeCreator(string entityName)
         {
-            if (!typeCreators.TryGetValue(entityName, out Func<IIdentifiable> typeCreator))
-            {
-                throw new InvalidOperationException($"The entity type '{entityName}' is not supported.");
-            }
-
-            return typeCreator;
+            return typeCreators.ContainsKey(entityName)
+                ? typeCreators[entityName]
+                : null;
         }
     }
 }

--- a/Intuit.TSheets/Intuit.TSheets.csproj
+++ b/Intuit.TSheets/Intuit.TSheets.csproj
@@ -9,15 +9,15 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Intuit</Authors>
     <PackageProjectUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</PackageProjectUrl>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <FileVersion>1.1.1.0</FileVersion>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <PackageIconUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK/images/tsheetsbyqb37.svg</PackageIconUrl>
     <RepositoryType>Git</RepositoryType>
-    <PackageReleaseNotes>New feature: get jobcodes by wildcardable name.</PackageReleaseNotes>
+    <PackageReleaseNotes>Bugfix: enable non-breaking introduction of new supplemental data sections.</PackageReleaseNotes>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
### What Changed?
Changing the EntityTypeMapper to return null instead of throwing, when an unknown supplemental data section is encountered.

### Why?
This is needed to facilitate non-breaking introduction of new supplemental data sections, as current behavior would cause fatal client exceptions.

### What else might be impacted?
Unknown sections will now be written to the logs as a warning.  These will be an indication that support for the new sections should be added.

## Checklist

- [x] Documentation
- [x] Unit Tests
- [x] Added self to contributors
- [x] Added SemVer label
- [x] Ready to be merged