### PR TITLE
Adding CancellationToken support for all asynchronous API methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.2.0 (Mon. Oct 21st, 2019)
+
+#### Minor Feature
+
+- Adding CancellationToken support for all asynchronous API methods.
+- Adding support for geofence_config object in supplemental data.
+
 # v1.1.2 (Tue. Sep 24th, 2019)
 
 #### Bugfix

--- a/Documentation/tsheets-sdk.md
+++ b/Documentation/tsheets-sdk.md
@@ -108,6 +108,12 @@ var jobcodeFilter = new JobcodeFilter
 ```cs
 // Retrieve the current user, asynchronously.
 (User user, ResultsMeta resultsMeta) = await apiClient.GetCurrentUserAsync().ConfigureAwait(false);
+
+// Retrieve all users, with a cancellation token.
+// If not yet complete, cancel after 200ms.
+var tokenSource = new CancellationTokenSource();
+tokenSource.CancelAfter(200);
+(IList<User> users, ResultsMeta resultsMeta) = await apiClient.GetUsersAsync(tokenSource.Token).ConfigureAwait(false);
 ```
 
 #### Auto-Paging Behavior

--- a/Intuit.TSheets.Examples/ExampleApp.cs
+++ b/Intuit.TSheets.Examples/ExampleApp.cs
@@ -36,6 +36,7 @@ namespace Intuit.TSheets.Examples
             this.appService = appService;
             this.logger = logger;
         }
+
         /// <summary>
         /// Runs the demonstration code in the app service.
         /// </summary>

--- a/Intuit.TSheets.Examples/ExampleAppService.cs
+++ b/Intuit.TSheets.Examples/ExampleAppService.cs
@@ -22,6 +22,7 @@ namespace Intuit.TSheets.Examples
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
     using Intuit.TSheets.Model;
@@ -82,6 +83,23 @@ namespace Intuit.TSheets.Examples
 
             // Retrieve some of the data we created.
             GetAsyncExample();
+            
+            // Retrieve users, but this time with a cancellation token.
+            // An OperationCanceledException will be thrown if the
+            // operation takes longer than 200ms to complete.
+            try
+            {
+                var tokenSource = new CancellationTokenSource();
+                tokenSource.CancelAfter(200);
+
+                this.apiClient.GetUsersAsync(
+                    new RequestOptions { PerPage = 1 },
+                    tokenSource.Token).GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException)
+            {
+                Console.WriteLine("Operation canceled.");
+            }
 
             // Cleanup everything that was added.
             Cleanup();
@@ -389,7 +407,7 @@ namespace Intuit.TSheets.Examples
             // Disable auto-paging to take direct control over results.  Retrieve a subset
             // of jobcodes, starting with page 2.
             Task<(IList<Jobcode>, ResultsMeta)> getJobcodesTask = this.apiClient.GetJobcodesAsync(
-                new RequestOptions { AutoPaging = false, Page = 2, PerPage = 2 });
+                new RequestOptions { AutoPaging = false, Page = 2, PerPage = 1 });
 
             // Block until both are finished
             Task.WaitAll(getUsersTask, getJobcodesTask);

--- a/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
+++ b/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
@@ -13,9 +13,9 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
     <PackageReleaseNotes />
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
-    <Version>1.1.2</Version>
-    <FileVersion>1.1.2.0</FileVersion>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <Version>1.2.0</Version>
+    <FileVersion>1.2.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
+++ b/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
@@ -16,6 +16,7 @@
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
     <Version>1.2.0</Version>
     <FileVersion>1.2.0.0</FileVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
+++ b/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
@@ -15,6 +15,7 @@
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
     <FileVersion>1.1.0.0</FileVersion>
     <Version>1.2.0</Version>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
+++ b/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
-    <FileVersion>1.1.2.0</FileVersion>
-    <Version>1.1.2</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
+++ b/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
-    <FileVersion>1.1.2.0</FileVersion>
-    <Version>1.1.2</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
+++ b/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
@@ -15,6 +15,7 @@
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
     <FileVersion>1.2.0.0</FileVersion>
     <Version>1.2.0</Version>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Intuit.TSheets.Tests/Unit/Api/DataServiceTestBase.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataServiceTestBase.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
     using Intuit.TSheets.Client.Core;
@@ -116,8 +117,8 @@ namespace Intuit.TSheets.Tests.Unit.Api
             where TContext : PipelineContext<TEntity>
         {
             this.mockPipeline
-                .Setup(f => f.ProcessAsync(It.IsAny<TContext>(), It.IsAny<ILogger>()))
-                .Callback((PipelineContext<TEntity> context, ILogger log) =>
+                .Setup(f => f.ProcessAsync(It.IsAny<TContext>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+                .Callback((PipelineContext<TEntity> context, ILogger log, CancellationToken cancellationToken) =>
                     Process(context, endpoint, expect))
                 .Returns(Task.CompletedTask);
 

--- a/Intuit.TSheets.Tests/Unit/Api/DataServiceTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataServiceTests.cs
@@ -1,0 +1,160 @@
+﻿// *******************************************************************************
+// <copyright file="DataService_CurrentUserTests.cs" company="Intuit">
+// Copyright (c) 2019 Intuit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// </copyright>
+// *******************************************************************************
+
+namespace Intuit.TSheets.Tests.Unit.Api
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Intuit.TSheets.Api;
+    using Intuit.TSheets.Client.Core;
+    using Intuit.TSheets.Client.RequestFlow.Contexts;
+    using Intuit.TSheets.Client.RequestFlow.Pipelines;
+    using Intuit.TSheets.Model.Exceptions;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class DataServiceTests : UnitTestBase
+    {
+        protected const int DummyPageNumber = 1;
+
+        private Mock<IPipelineFactory> mockPipelineFactory;
+        private Mock<IRestClient> mockRestClient;
+
+        private DataService apiService;
+
+        [TestInitialize]
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            this.mockPipelineFactory = new Mock<IPipelineFactory>(MockBehavior.Strict);
+            this.mockRestClient = new Mock<IRestClient>(MockBehavior.Strict);
+
+            this.apiService = new DataService(
+                this.mockPipelineFactory.Object,
+                this.mockRestClient.Object,
+                MockLogger.Object);
+        }
+
+        [TestMethod, TestCategory("Unit")]
+        public async Task ExecuteOperationAsync_OperationCanceledExceptionIsUnhandled()
+        {
+            var mockPipeline = new Mock<IPipeline>(MockBehavior.Strict);
+
+            mockPipeline
+                .Setup(h => h.ProcessAsync(
+                    It.IsAny<PipelineContext<BasicTestEntity>>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback((PipelineContext<BasicTestEntity> context, ILogger log, CancellationToken cancellationToken) => {
+                    cancellationToken.ThrowIfCancellationRequested();
+                })
+                .Returns(Task.CompletedTask);
+
+            this.mockPipelineFactory
+                .Setup(h => h.GetPipeline(
+                    It.IsAny<PipelineContext<BasicTestEntity>>()))
+                .Returns(mockPipeline.Object);
+
+            var getContext = new GetContext<BasicTestEntity>(EndpointName.Tests, null);
+
+            var tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            try
+            {
+                await this.apiService.ExecuteOperationAsync(getContext, tokenSource.Token).ConfigureAwait(false);
+                Assert.Fail($"Expected {nameof(OperationCanceledException)} to be thrown.");
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        [TestMethod, TestCategory("Unit")]
+        public async Task ExecuteOperationAsync_ApiExceptionsAreUnhandled()
+        {
+            var mockPipeline = new Mock<IPipeline>(MockBehavior.Strict);
+
+            mockPipeline
+                .Setup(h => h.ProcessAsync(
+                    It.IsAny<PipelineContext<BasicTestEntity>>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback((PipelineContext<BasicTestEntity> context, ILogger log, CancellationToken cancellationToken) => {
+                    throw new ConflictException("conflict", "conflict", null);
+                })
+                .Returns(Task.CompletedTask);
+
+            this.mockPipelineFactory
+                .Setup(h => h.GetPipeline(
+                    It.IsAny<PipelineContext<BasicTestEntity>>()))
+                .Returns(mockPipeline.Object);
+
+            var getContext = new GetContext<BasicTestEntity>(EndpointName.Tests, null);
+
+            var tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+
+            try
+            {
+                await this.apiService.ExecuteOperationAsync(getContext, tokenSource.Token).ConfigureAwait(false);
+                Assert.Fail($"Expected {nameof(ConflictException)} to be thrown.");
+            }
+            catch (ConflictException) { }
+        }
+
+        [TestMethod, TestCategory("Unit")]
+        public async Task ExecuteOperationAsync_UnexpectedExceptionIsWrappedInFatalClientException()
+        {
+            var mockPipeline = new Mock<IPipeline>(MockBehavior.Strict);
+
+            // some unexpected exception
+            var innerException = new UnauthorizedAccessException();
+
+            mockPipeline
+                .Setup(h => h.ProcessAsync(
+                    It.IsAny<PipelineContext<BasicTestEntity>>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback((PipelineContext<BasicTestEntity> context, ILogger log, CancellationToken cancellationToken) => {
+                    throw innerException;  
+                })
+                .Returns(Task.CompletedTask);
+
+            this.mockPipelineFactory
+                .Setup(h => h.GetPipeline(
+                    It.IsAny<PipelineContext<BasicTestEntity>>()))
+                .Returns(mockPipeline.Object);
+
+            var getContext = new GetContext<BasicTestEntity>(EndpointName.Tests, null);
+
+            try
+            {
+                await this.apiService.ExecuteOperationAsync(getContext, default).ConfigureAwait(false);
+                Assert.Fail($"Expected {nameof(FatalClientException)} to be thrown.");
+            }
+            catch (FatalClientException e)
+            {
+                Assert.IsInstanceOfType(e.InnerException, innerException.GetType());
+            }
+        }
+    }
+}

--- a/Intuit.TSheets.Tests/Unit/Client/Core/ConnectionInfoTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/Core/ConnectionInfoTests.cs
@@ -39,12 +39,6 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
         }
 
         [TestMethod, TestCategory("Unit")]
-        public void ConnectionInfo_SecurityProtocolDefaultsToTls12()
-        {
-            Assert.AreEqual(SecurityProtocolType.Tls12, ConnectionInfo.SecurityProtocol);
-        }
-
-        [TestMethod, TestCategory("Unit")]
         public void ConnectionInfo_SecurityProtocolCanBeConfigured()
         {
             var expectedProtocolType = SecurityProtocolType.Tls11;

--- a/Intuit.TSheets.Tests/Unit/Client/Core/ResilientRestClientTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/Core/ResilientRestClientTests.cs
@@ -22,6 +22,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
     using Intuit.TSheets.Client.Core;
@@ -69,14 +70,15 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.CreateAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<string>(j => j.Equals(this.inputData)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
-                .Callback((EndpointName en, string jd, LogContext lc)
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
+                .Callback((EndpointName en, string jd, LogContext lc, CancellationToken ct)
                     => throw new ServiceUnavailableException("Something went wrong."));
 
             try
             {
                 IRestClient restClient = GetRestClientWithRetries();
-                await restClient.CreateAsync(this.endpointName, this.inputData, this.logContext);
+                await restClient.CreateAsync(this.endpointName, this.inputData, this.logContext, default);
                 Assert.Fail("Expected exception to be thrown.");
             }
             catch (ServiceUnavailableException)
@@ -84,7 +86,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             }
 
             // Verify our inner rest client was called 4 times (original invocation + retries)
-            this.mockRestClient.Verify(m => m.CreateAsync(this.endpointName, this.inputData, this.logContext),
+            this.mockRestClient.Verify(m => m.CreateAsync(this.endpointName, this.inputData, this.logContext, default),
                 Times.Exactly(RetryCount + 1));
         }
 
@@ -97,17 +99,18 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.CreateAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<string>(j => j.Equals(this.inputData)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult("Done."));
 
             IRestClient restClient = GetRestClientWithRetries();
             
-            string result = await restClient.CreateAsync(this.endpointName, this.inputData, this.logContext);
+            string result = await restClient.CreateAsync(this.endpointName, this.inputData, this.logContext, default);
 
             Assert.AreEqual(SuccessResult, result, $"Expected result: '{SuccessResult}'.");
 
             // Verify our inner rest client was called only once.
-            this.mockRestClient.Verify(m => m.CreateAsync(this.endpointName, this.inputData, this.logContext),
+            this.mockRestClient.Verify(m => m.CreateAsync(this.endpointName, this.inputData, this.logContext, default),
                 Times.Once);
         }
 
@@ -120,15 +123,16 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.CreateAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<string>(j => j.Equals(this.inputData)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
-                .Callback((EndpointName en, string jd, LogContext lc)
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
+                .Callback((EndpointName en, string jd, LogContext lc, CancellationToken ct)
                     => throw new BadRequestException("Bad request."));
 
             IRestClient restClient = GetRestClientWithRetries();
 
             try
             {
-                await restClient.CreateAsync(this.endpointName, this.inputData, this.logContext);
+                await restClient.CreateAsync(this.endpointName, this.inputData, this.logContext, default);
                 Assert.Fail("Expected exception to be thrown.");
             }
             catch (BadRequestException)
@@ -136,7 +140,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             }
 
             // Verify our inner rest client was called exactly once.
-            this.mockRestClient.Verify(m => m.CreateAsync(this.endpointName, this.inputData, this.logContext),
+            this.mockRestClient.Verify(m => m.CreateAsync(this.endpointName, this.inputData, this.logContext, default),
                 Times.Once);
         }
 
@@ -149,14 +153,15 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.GetAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<Dictionary<string, string>>(j => j.Equals(this.inputFilter)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
-                .Callback((EndpointName en, Dictionary<string, string> fi, LogContext lc)
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
+                .Callback((EndpointName en, Dictionary<string, string> fi, LogContext lc, CancellationToken ct)
                     => throw new ServiceUnavailableException("Something went wrong."));
 
             try
             {
                 IRestClient restClient = GetRestClientWithRetries();
-                await restClient.GetAsync(this.endpointName, this.inputFilter, this.logContext);
+                await restClient.GetAsync(this.endpointName, this.inputFilter, this.logContext, default);
                 Assert.Fail("Expected exception to be thrown.");
             }
             catch (ServiceUnavailableException)
@@ -164,7 +169,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             }
 
             // Verify our inner rest client was called 4 times (original invocation + retries)
-            this.mockRestClient.Verify(m => m.GetAsync(this.endpointName, this.inputFilter, this.logContext),
+            this.mockRestClient.Verify(m => m.GetAsync(this.endpointName, this.inputFilter, this.logContext, default),
                 Times.Exactly(RetryCount + 1));
         }
 
@@ -177,17 +182,18 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.GetAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<Dictionary<string, string>>(j => j.Equals(this.inputFilter)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult("Done."));
 
             IRestClient restClient = GetRestClientWithRetries();
 
-            string result = await restClient.GetAsync(this.endpointName, this.inputFilter, this.logContext);
+            string result = await restClient.GetAsync(this.endpointName, this.inputFilter, this.logContext, default);
 
             Assert.AreEqual(SuccessResult, result, $"Expected result: '{SuccessResult}'.");
 
             // Verify our inner rest client was called only once.
-            this.mockRestClient.Verify(m => m.GetAsync(this.endpointName, this.inputFilter, this.logContext),
+            this.mockRestClient.Verify(m => m.GetAsync(this.endpointName, this.inputFilter, this.logContext, default),
                 Times.Once);
         }
 
@@ -200,14 +206,15 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.GetAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<Dictionary<string, string>>(j => j.Equals(this.inputFilter)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
-                .Callback((EndpointName en, Dictionary<string, string> fi, LogContext lc)
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
+                .Callback((EndpointName en, Dictionary<string, string> fi, LogContext lc, CancellationToken ct)
                     => throw new BadRequestException("Bad request."));
 
             try
             {
                 IRestClient restClient = GetRestClientWithRetries();
-                await restClient.GetAsync(this.endpointName, this.inputFilter, this.logContext);
+                await restClient.GetAsync(this.endpointName, this.inputFilter, this.logContext, default);
                 Assert.Fail("Expected exception to be thrown.");
             }
             catch (BadRequestException)
@@ -215,7 +222,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             }
 
             // Verify our inner rest client was called exactly once.
-            this.mockRestClient.Verify(m => m.GetAsync(this.endpointName, this.inputFilter, this.logContext),
+            this.mockRestClient.Verify(m => m.GetAsync(this.endpointName, this.inputFilter, this.logContext, default),
                 Times.Once);
         }
 
@@ -228,14 +235,15 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.DownloadAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<Dictionary<string, string>>(j => j.Equals(this.inputFilter)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
-                .Callback((EndpointName en, Dictionary<string, string> fi, LogContext lc)
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
+                .Callback((EndpointName en, Dictionary<string, string> fi, LogContext lc, CancellationToken ct)
                     => throw new ServiceUnavailableException("Something went wrong."));
 
             try
             {
                 IRestClient restClient = GetRestClientWithRetries();
-                await restClient.DownloadAsync(this.endpointName, this.inputFilter, this.logContext);
+                await restClient.DownloadAsync(this.endpointName, this.inputFilter, this.logContext, default);
                 Assert.Fail("Expected exception to be thrown.");
             }
             catch (ServiceUnavailableException)
@@ -243,7 +251,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             }
 
             // Verify our inner rest client was called 4 times (original invocation + retries)
-            this.mockRestClient.Verify(m => m.DownloadAsync(this.endpointName, this.inputFilter, this.logContext),
+            this.mockRestClient.Verify(m => m.DownloadAsync(this.endpointName, this.inputFilter, this.logContext, default),
                 Times.Exactly(RetryCount + 1));
         }
 
@@ -256,18 +264,19 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.DownloadAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<Dictionary<string, string>>(j => j.Equals(this.inputFilter)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Encoding.UTF8.GetBytes(SuccessResult)));
 
             IRestClient restClient = GetRestClientWithRetries();
 
-            byte[] result = await restClient.DownloadAsync(this.endpointName, this.inputFilter, this.logContext);
+            byte[] result = await restClient.DownloadAsync(this.endpointName, this.inputFilter, this.logContext, default);
             string resultString = Encoding.UTF8.GetString(result);
 
             Assert.AreEqual(SuccessResult, resultString, $"Expected result: '{SuccessResult}'.");
 
             // Verify our inner rest client was called only once.
-            this.mockRestClient.Verify(m => m.DownloadAsync(this.endpointName, this.inputFilter, this.logContext),
+            this.mockRestClient.Verify(m => m.DownloadAsync(this.endpointName, this.inputFilter, this.logContext, default),
                 Times.Once);
         }
 
@@ -280,14 +289,15 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.DownloadAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<Dictionary<string, string>>(j => j.Equals(this.inputFilter)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
-                .Callback((EndpointName en, Dictionary<string, string> fi, LogContext lc)
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
+                .Callback((EndpointName en, Dictionary<string, string> fi, LogContext lc, CancellationToken ct)
                     => throw new BadRequestException("Bad request."));
 
             try
             {
                 IRestClient restClient = GetRestClientWithRetries();
-                await restClient.DownloadAsync(this.endpointName, this.inputFilter, this.logContext);
+                await restClient.DownloadAsync(this.endpointName, this.inputFilter, this.logContext, default);
                 Assert.Fail("Expected exception to be thrown.");
             }
             catch (BadRequestException)
@@ -295,7 +305,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             }
 
             // Verify our inner rest client was called exactly once.
-            this.mockRestClient.Verify(m => m.DownloadAsync(this.endpointName, this.inputFilter, this.logContext),
+            this.mockRestClient.Verify(m => m.DownloadAsync(this.endpointName, this.inputFilter, this.logContext, default),
                 Times.Once);
         }
 
@@ -308,14 +318,15 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.UpdateAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<string>(j => j.Equals(this.inputData)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
-                .Callback((EndpointName en, string jd, LogContext lc)
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
+                .Callback((EndpointName en, string jd, LogContext lc, CancellationToken ct)
                     => throw new ServiceUnavailableException("Something went wrong."));
 
             try
             {
                 IRestClient restClient = GetRestClientWithRetries();
-                await restClient.UpdateAsync(this.endpointName, this.inputData, this.logContext);
+                await restClient.UpdateAsync(this.endpointName, this.inputData, this.logContext, default);
                 Assert.Fail("Expected exception to be thrown.");
             }
             catch (ServiceUnavailableException)
@@ -323,7 +334,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             }
 
             // Verify our inner rest client was called 4 times (original invocation + retries)
-            this.mockRestClient.Verify(m => m.UpdateAsync(this.endpointName, this.inputData, this.logContext),
+            this.mockRestClient.Verify(m => m.UpdateAsync(this.endpointName, this.inputData, this.logContext, default),
                 Times.Exactly(RetryCount + 1));
         }
 
@@ -336,17 +347,18 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.UpdateAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<string>(j => j.Equals(this.inputData)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult("Done."));
 
             IRestClient restClient = GetRestClientWithRetries();
             
-            string result = await restClient.UpdateAsync(this.endpointName, this.inputData, this.logContext);
+            string result = await restClient.UpdateAsync(this.endpointName, this.inputData, this.logContext, default);
 
             Assert.AreEqual(SuccessResult, result, $"Expected result: '{SuccessResult}'.");
 
             // Verify our inner rest client was called only once.
-            this.mockRestClient.Verify(m => m.UpdateAsync(this.endpointName, this.inputData, this.logContext),
+            this.mockRestClient.Verify(m => m.UpdateAsync(this.endpointName, this.inputData, this.logContext, default),
                 Times.Once);
         }
 
@@ -359,14 +371,15 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.UpdateAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<string>(j => j.Equals(this.inputData)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
-                .Callback((EndpointName en, string jd, LogContext lc)
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
+                .Callback((EndpointName en, string jd, LogContext lc, CancellationToken ct)
                     => throw new BadRequestException("Bad request."));
 
             try
             {
                 IRestClient restClient = GetRestClientWithRetries();
-                await restClient.UpdateAsync(this.endpointName, this.inputData, this.logContext);
+                await restClient.UpdateAsync(this.endpointName, this.inputData, this.logContext, default);
                 Assert.Fail("Expected exception to be thrown.");
             }
             catch (BadRequestException)
@@ -374,7 +387,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             }
 
             // Verify our inner rest client was called exactly once.
-            this.mockRestClient.Verify(m => m.UpdateAsync(this.endpointName, this.inputData, this.logContext),
+            this.mockRestClient.Verify(m => m.UpdateAsync(this.endpointName, this.inputData, this.logContext, default),
                 Times.Once);
         }
 
@@ -387,14 +400,15 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.DeleteAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<IEnumerable<int>>(j => j.Equals(this.deleteIds)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
-                .Callback((EndpointName en, IEnumerable<int> di, LogContext lc)
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
+                .Callback((EndpointName en, IEnumerable<int> di, LogContext lc, CancellationToken ct)
                     => throw new ServiceUnavailableException("Something went wrong."));
 
             try
             {
                 IRestClient restClient = GetRestClientWithRetries();
-                await restClient.DeleteAsync(this.endpointName, this.deleteIds, this.logContext);
+                await restClient.DeleteAsync(this.endpointName, this.deleteIds, this.logContext, default);
                 Assert.Fail("Expected exception to be thrown.");
             }
             catch (ServiceUnavailableException)
@@ -402,7 +416,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             }
 
             // Verify our inner rest client was called 4 times (original invocation + retries)
-            this.mockRestClient.Verify(m => m.DeleteAsync(this.endpointName, this.deleteIds, this.logContext),
+            this.mockRestClient.Verify(m => m.DeleteAsync(this.endpointName, this.deleteIds, this.logContext, default),
                 Times.Exactly(RetryCount + 1));
         }
 
@@ -415,17 +429,18 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.DeleteAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<IEnumerable<int>>(j => j.Equals(this.deleteIds)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult("Done."));
 
             IRestClient restClient = GetRestClientWithRetries();
 
-            string result = await restClient.DeleteAsync(this.endpointName, this.deleteIds, this.logContext);
+            string result = await restClient.DeleteAsync(this.endpointName, this.deleteIds, this.logContext, default);
 
             Assert.AreEqual(SuccessResult, result, $"Expected result: '{SuccessResult}'.");
 
             // Verify our inner rest client was called only once.
-            this.mockRestClient.Verify(m => m.DeleteAsync(this.endpointName, this.deleteIds, this.logContext),
+            this.mockRestClient.Verify(m => m.DeleteAsync(this.endpointName, this.deleteIds, this.logContext, default),
                 Times.Once);
         }
 
@@ -438,14 +453,15 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 .Setup(c => c.DeleteAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
                     It.Is<IEnumerable<int>>(j => j.Equals(this.deleteIds)),
-                    It.Is<LogContext>(l => l.Equals(this.logContext))))
-                .Callback((EndpointName en, IEnumerable<int> di, LogContext lc)
+                    It.Is<LogContext>(l => l.Equals(this.logContext)),
+                    It.IsAny<CancellationToken>()))
+                .Callback((EndpointName en, IEnumerable<int> di, LogContext lc, CancellationToken ct)
                     => throw new BadRequestException("Bad request."));
 
             try
             {
                 IRestClient restClient = GetRestClientWithRetries();
-                await restClient.DeleteAsync(this.endpointName, this.deleteIds, this.logContext);
+                await restClient.DeleteAsync(this.endpointName, this.deleteIds, this.logContext, default);
                 Assert.Fail("Expected exception to be thrown.");
             }
             catch (BadRequestException)
@@ -453,7 +469,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             }
 
             // Verify our inner rest client was called exactly once.
-            this.mockRestClient.Verify(m => m.DeleteAsync(this.endpointName, this.deleteIds, this.logContext),
+            this.mockRestClient.Verify(m => m.DeleteAsync(this.endpointName, this.deleteIds, this.logContext, default),
                 Times.Once);
         }
 

--- a/Intuit.TSheets.Tests/Unit/Client/Core/RestClientTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/Core/RestClientTests.cs
@@ -136,7 +136,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            var actualResponse = await restClient.CreateAsync(EndpointName.Tests, "input data", new LogContext()).ConfigureAwait(false);
+            var actualResponse = await restClient.CreateAsync(EndpointName.Tests, "input data", new LogContext(), default).ConfigureAwait(false);
 
             Assert.AreEqual(expectedResponse, actualResponse);
         }
@@ -165,7 +165,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            await restClient.CreateAsync(EndpointName.Tests, expectedRequest, new LogContext()).ConfigureAwait(false);
+            await restClient.CreateAsync(EndpointName.Tests, expectedRequest, new LogContext(), default).ConfigureAwait(false);
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -186,7 +186,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            var actualResponse = await restClient.CreateAsync(EndpointName.Tests, "input data", new LogContext()).ConfigureAwait(false);
+            var actualResponse = await restClient.CreateAsync(EndpointName.Tests, "input data", new LogContext(), default).ConfigureAwait(false);
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -206,7 +206,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            var actualResponse = await restClient.UpdateAsync(EndpointName.Tests, "input data", new LogContext()).ConfigureAwait(false);
+            var actualResponse = await restClient.UpdateAsync(EndpointName.Tests, "input data", new LogContext(), default).ConfigureAwait(false);
 
             Assert.AreEqual(expectedResponse, actualResponse);
         }
@@ -235,7 +235,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            await restClient.UpdateAsync(EndpointName.Tests, expectedRequest, new LogContext()).ConfigureAwait(false);
+            await restClient.UpdateAsync(EndpointName.Tests, expectedRequest, new LogContext(), default).ConfigureAwait(false);
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -256,7 +256,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            var actualResponse = await restClient.UpdateAsync(EndpointName.Tests, "input data", new LogContext()).ConfigureAwait(false);
+            var actualResponse = await restClient.UpdateAsync(EndpointName.Tests, "input data", new LogContext(), default).ConfigureAwait(false);
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -276,7 +276,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            var actualResponse = await restClient.GetAsync(EndpointName.Tests, null, new LogContext()).ConfigureAwait(false);
+            var actualResponse = await restClient.GetAsync(EndpointName.Tests, null, new LogContext(), default).ConfigureAwait(false);
 
             Assert.AreEqual(expectedResponse, actualResponse);
         }
@@ -308,7 +308,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            await restClient.GetAsync(EndpointName.Tests, filters, new LogContext()).ConfigureAwait(false);
+            await restClient.GetAsync(EndpointName.Tests, filters, new LogContext(), default).ConfigureAwait(false);
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -333,7 +333,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            var actualResponse = await restClient.GetAsync(EndpointName.Tests, filters, new LogContext()).ConfigureAwait(false);
+            var actualResponse = await restClient.GetAsync(EndpointName.Tests, filters, new LogContext(), default).ConfigureAwait(false);
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -353,7 +353,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            var actualResponse = await restClient.DownloadAsync(EndpointName.Tests, null, new LogContext()).ConfigureAwait(false);
+            var actualResponse = await restClient.DownloadAsync(EndpointName.Tests, null, new LogContext(), default).ConfigureAwait(false);
 
             Assert.IsTrue(expectedResponse.SequenceEqual(actualResponse));
         }
@@ -385,7 +385,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            await restClient.DownloadAsync(EndpointName.Tests, filters, new LogContext()).ConfigureAwait(false);
+            await restClient.DownloadAsync(EndpointName.Tests, filters, new LogContext(), default).ConfigureAwait(false);
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -410,7 +410,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            var actualResponse = await restClient.DownloadAsync(EndpointName.Tests, filters, new LogContext()).ConfigureAwait(false);
+            var actualResponse = await restClient.DownloadAsync(EndpointName.Tests, filters, new LogContext(), default).ConfigureAwait(false);
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -431,7 +431,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            var actualResponse = await restClient.DeleteAsync(EndpointName.Tests, expectedRequest, new LogContext()).ConfigureAwait(false);
+            var actualResponse = await restClient.DeleteAsync(EndpointName.Tests, expectedRequest, new LogContext(), default).ConfigureAwait(false);
 
             Assert.AreEqual(expectedResponse, actualResponse);
         }
@@ -459,7 +459,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            await restClient.DeleteAsync(EndpointName.Tests, expectedRequest, new LogContext()).ConfigureAwait(false);
+            await restClient.DeleteAsync(EndpointName.Tests, expectedRequest, new LogContext(), default).ConfigureAwait(false);
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -480,7 +480,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
                 mockHttpClient,
                 this.mockLogger.Object);
 
-            var actualResponse = await restClient.DeleteAsync(EndpointName.Tests, expectedRequest, new LogContext()).ConfigureAwait(false);
+            var actualResponse = await restClient.DeleteAsync(EndpointName.Tests, expectedRequest, new LogContext(), default).ConfigureAwait(false);
         }
 
         private HttpClient GetMockHttpClient(

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/CreateContextValidatorTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/CreateContextValidatorTests.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -45,7 +46,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         {
             var context = new CreateContext<TestEntity>(EndpointName.Tests, null);
 
-            await this.pipelineElement.ProcessAsync(context, MockLogger.Object)
+            await this.pipelineElement.ProcessAsync(context, MockLogger.Object, default)
                 .ConfigureAwait(false);
         }
 
@@ -55,7 +56,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         {
             var context = new CreateContext<TestEntity>(EndpointName.Tests, new List<TestEntity>());
 
-            await this.pipelineElement.ProcessAsync(context, MockLogger.Object)
+            await this.pipelineElement.ProcessAsync(context, MockLogger.Object, default)
                 .ConfigureAwait(false);
         }
 

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/CreateRequestSerializerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/CreateRequestSerializerTests.cs
@@ -106,7 +106,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         {
             CreateContext<T> context = GetCreateContext(entityToSerialize);
 
-            AsyncUtil.RunSync(() => this.pipelineElement.ProcessAsync(context, NullLogger.Instance));
+            AsyncUtil.RunSync(() => this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default));
 
             TestHelper.AssertJsonEqual(expectedSerialization, context.SerializedRequest);
         }

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/DeleteContextValidatorTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/DeleteContextValidatorTests.cs
@@ -45,7 +45,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         {
             var context = new DeleteContext<TestEntity>(EndpointName.Tests, null);
 
-            await this.pipelineElement.ProcessAsync(context, MockLogger.Object)
+            await this.pipelineElement.ProcessAsync(context, MockLogger.Object, default)
                 .ConfigureAwait(false);
         }
 
@@ -55,7 +55,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         {
             var context = new DeleteContext<TestEntity>(EndpointName.Tests, new List<int>());
 
-            await this.pipelineElement.ProcessAsync(context, MockLogger.Object)
+            await this.pipelineElement.ProcessAsync(context, MockLogger.Object, default)
                 .ConfigureAwait(false);
         }
 

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/DeleteResultsDeserializerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/DeleteResultsDeserializerTests.cs
@@ -42,7 +42,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         public async Task DeleteResultsSerializer_CorrectlyDeserializesSuccessfulResponseAsync()
         {
             DeleteContext<TestEntity> context = GetDeleteContext<TestEntity>();
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             const int expectedCount = 0;
             Assert.AreEqual(expectedCount, context.Results.ErrorItems.Count, $"Expected {expectedCount} error results.");
@@ -52,7 +52,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         public async Task DeleteResultsSerializer_CorrectlyDeserializesResponseWithErrorResultsAsync()
         {
             DeleteContext<TestEntity> context = GetDeleteContextWithErrorItems<TestEntity>();
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             const int expectedCount = 2;
             Assert.AreEqual(expectedCount, context.Results.ErrorItems.Count, $"Expected {expectedCount} error results.");

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/GetReportDeserializerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/GetReportDeserializerTests.cs
@@ -45,7 +45,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
             var expectedItem1 = new TestReportItem(1237, "Mary", 90.5f);
 
             GetReportContext<TestReport> context = GetReportContext<TestReport>();
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             const int expectedCount = 2;
             Assert.AreEqual(expectedCount, context.Results.Report.Count, $"Expected {expectedCount} items in the report.");

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/GetReportSerializerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/GetReportSerializerTests.cs
@@ -83,7 +83,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         private void AssertSerializesAsExpected<T>(EntityFilter filterToBeSerialized, string expectedSerialization)
         {
             GetReportContext<T> context = GetReportContext<T>(filterToBeSerialized);
-            AsyncUtil.RunSync(() => this.pipelineElement.ProcessAsync(context, NullLogger.Instance));
+            AsyncUtil.RunSync(() => this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default));
 
             TestHelper.AssertJsonEqual(expectedSerialization, context.SerializedRequest);
         }

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/GetResultsDeserializerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/GetResultsDeserializerTests.cs
@@ -45,7 +45,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
             var expectedResult1 = new BasicTestEntity(2, "Mary");
 
             GetContext<BasicTestEntity> context = GetContext<BasicTestEntity>();
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             const int expectedCount = 2;
             Assert.AreEqual(expectedCount, context.Results.Items.Count, $"Expected {expectedCount} results.");
@@ -67,7 +67,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 }"
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             const int expectedCount = 0;
             Assert.AreEqual(expectedCount, context.Results.Items.Count, $"Expected {expectedCount} results.");
@@ -85,7 +85,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 }"
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             const int expectedCount = 0;
             Assert.AreEqual(expectedCount, context.Results.Items.Count, $"Expected {expectedCount} results.");

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/GetResultsMetaDeserializerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/GetResultsMetaDeserializerTests.cs
@@ -47,7 +47,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 ResponseContent = @"{ ""more"": true }"
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             Assert.IsTrue(context.ResultsMeta.More, "Expected ResultsMeta.More to be true");
         }
@@ -60,7 +60,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 ResponseContent = @"{ ""more"": false }"
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             Assert.IsFalse(context.ResultsMeta.More, "Expected ResultsMeta.More to be false");
         }
@@ -73,7 +73,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 ResponseContent = @"{ ""more_is_not_present"": ""expect false"" }"
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             Assert.IsFalse(context.ResultsMeta.More, "Expected ResultsMeta.More to be false");
         }
@@ -88,7 +88,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 ResponseContent = @"{ ""more"": false }"
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             Assert.AreEqual(expectedPage, context.ResultsMeta.Page, $"Expected ResultsMeta.Page to be {expectedPage}.");
         }

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/ModificationResultsDeserializerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/ModificationResultsDeserializerTests.cs
@@ -47,7 +47,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
             var expectedResult2 = new BasicTestEntity(2737, "Muriel");
 
             UpdateContext<BasicTestEntity> context = GetUpdateContext();
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             const int expectedCount = 2;
             Assert.AreEqual(expectedCount, context.Results.Items.Count, $"Expected {expectedCount} success results.");
@@ -85,7 +85,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 });
 
             UpdateContext<BasicTestEntity> context = GetUpdateContextWithErrorResults();
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             const int expectedCount = 2;
             Assert.AreEqual(expectedCount, context.Results.ErrorItems.Count, $"Expected {expectedCount} error results.");

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/MultiStatusHandlerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/MultiStatusHandlerTests.cs
@@ -47,7 +47,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         {
             var context = new CreateContext<BasicTestEntity>(EndpointName.Tests, new[]{ new BasicTestEntity() });
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -58,7 +58,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 Results = new Results<BasicTestEntity>()
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -79,7 +79,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
 
             try
             {
-                await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+                await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
                 Assert.Fail("Expected MultiStatusException to be thrown");
             }

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/PipelineElementTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/PipelineElementTests.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Intuit.TSheets.Client.RequestFlow.PipelineElements;
@@ -53,7 +54,10 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
             {
             }
 
-            protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+            protected override Task _ProcessAsync<T>(
+                PipelineContext<T> context,
+                ILogger logger,
+                CancellationToken cancellationToken)
             {
                 logger?.Log(LogLevel.Debug, InfoLogMessageAsync);
 

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/RestClientDeleteHandlerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/RestClientDeleteHandlerTests.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -51,8 +52,11 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
             // rest client Delete() method is called with 3 parameters: 
             // the request id, the endpoint, and the list of id's to delete
             this.mockRestClient
-                .Setup(p => p.DeleteAsync(It.Is<EndpointName>(t => t.Equals(EndpointName.Tests)),
-                    It.Is<IEnumerable<int>>(s => s.IsEqualTo(idsToDelete)), It.IsAny<LogContext>()))
+                .Setup(p => p.DeleteAsync(
+                    It.Is<EndpointName>(t => t.Equals(EndpointName.Tests)),
+                    It.Is<IEnumerable<int>>(s => s.IsEqualTo(idsToDelete)),
+                    It.IsAny<LogContext>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response));
 
             var context = new DeleteContext<BasicTestEntity>(EndpointName.Tests, idsToDelete)
@@ -60,7 +64,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 RestClient = this.mockRestClient.Object
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             this.mockRestClient.VerifyAll();
         }
@@ -69,8 +73,11 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         public async Task RestClientDeleteHandler_RestClientSetsResponseContentPropertyOfContextObjectAsync()
         {
             this.mockRestClient
-                .Setup(p => p.DeleteAsync(It.IsAny<EndpointName>(),
-                    It.IsAny<IEnumerable<int>>(), It.IsAny<LogContext>()))
+                .Setup(p => p.DeleteAsync(
+                    It.IsAny<EndpointName>(),
+                    It.IsAny<IEnumerable<int>>(),
+                    It.IsAny<LogContext>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response));
 
             var context = new DeleteContext<BasicTestEntity>(EndpointName.Tests, new[] {1})
@@ -78,7 +85,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 RestClient = this.mockRestClient.Object
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default);
 
             Assert.AreEqual(Response, context.ResponseContent, "Expected response content to be set.");
 

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/RestClientGetHandlerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/RestClientGetHandlerTests.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
     using Intuit.TSheets.Client.Core;
@@ -52,13 +53,16 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
             // rest client Get() method is called with 3 parameters: 
             // the request id, the endpoint, and the dictionary of filter settings
             this.mockRestClient
-                .Setup(p => p.GetAsync(It.Is<EndpointName>(t => t.Equals(EndpointName.Tests)),
-                    It.Is<Dictionary<string, string>>(s => s.IsEqualTo(ExpectedFilters)), It.IsAny<LogContext>()))
+                .Setup(p => p.GetAsync(
+                    It.Is<EndpointName>(t => t.Equals(EndpointName.Tests)),
+                    It.Is<Dictionary<string, string>>(s => s.IsEqualTo(ExpectedFilters)),
+                    It.IsAny<LogContext>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response));
 
             context.RestClient = this.mockRestClient.Object;
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             this.mockRestClient.VerifyAll();
         }
@@ -67,14 +71,17 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         public async Task RestClientGetHandler_RestClientSetsResponseContentPropertyOfContextObjectAsync()
         {
             this.mockRestClient
-                .Setup(p => p.GetAsync(It.IsAny<EndpointName>(),
-                    It.IsAny<Dictionary<string, string>>(), It.IsAny<LogContext>()))
+                .Setup(p => p.GetAsync(
+                    It.IsAny<EndpointName>(),
+                    It.IsAny<Dictionary<string, string>>(),
+                    It.IsAny<LogContext>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response));
 
             GetContext<BasicTestEntity> context = GetContext();
             context.RestClient = this.mockRestClient.Object;
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             Assert.AreEqual(Response, context.ResponseContent, "Expected response content to be set.");
 

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/RestClientPostHandlerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/RestClientPostHandlerTests.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -51,13 +52,16 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
             // rest client Create() method is called with 3 parameters: 
             // the request id, the endpoint, and the serialized request string
             this.mockRestClient
-                .Setup(p => p.CreateAsync(It.Is<EndpointName>(t => t.Equals(EndpointName.Tests)),
-                    It.Is<string>(s => s.Equals(Request)), It.IsAny<LogContext>()))
+                .Setup(p => p.CreateAsync(
+                    It.Is<EndpointName>(t => t.Equals(EndpointName.Tests)),
+                    It.Is<string>(s => s.Equals(Request)),
+                    It.IsAny<LogContext>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response));
 
             context.RestClient = this.mockRestClient.Object;
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             this.mockRestClient.VerifyAll();
         }
@@ -68,13 +72,16 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
             CreateContext<TestEntity> context = GetCreateContext();
 
             this.mockRestClient
-                .Setup(p => p.CreateAsync(It.IsAny<EndpointName>(),
-                    It.IsAny<string>(), It.IsAny<LogContext>()))
+                .Setup(p => p.CreateAsync(
+                    It.IsAny<EndpointName>(),
+                    It.IsAny<string>(),
+                    It.IsAny<LogContext>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response));
 
             context.RestClient = this.mockRestClient.Object;
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             Assert.AreEqual(Response, context.ResponseContent, "Expected response content to be set.");
 

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/RestClientPutHandlerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/RestClientPutHandlerTests.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -50,13 +51,16 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
             // rest client Update() method is called with 3 parameters: 
             // the request id, the endpoint, and the serialized request string
             this.mockRestClient
-                .Setup(p => p.UpdateAsync(It.Is<EndpointName>(t => t.Equals(EndpointName.Tests)),
-                    It.Is<string>(s => s.Equals(Request)), It.IsAny<LogContext>()))
+                .Setup(p => p.UpdateAsync(
+                    It.Is<EndpointName>(t => t.Equals(EndpointName.Tests)),
+                    It.Is<string>(s => s.Equals(Request)),
+                    It.IsAny<LogContext>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response));
 
             context.RestClient = this.mockRestClient.Object;
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             this.mockRestClient.VerifyAll();
         }
@@ -67,13 +71,16 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
             UpdateContext<TestEntity> context = GetUpdateContext();
 
             this.mockRestClient
-                .Setup(p => p.UpdateAsync(It.IsAny<EndpointName>(),
-                    It.IsAny<string>(), It.IsAny<LogContext>()))
+                .Setup(p => p.UpdateAsync(
+                    It.IsAny<EndpointName>(),
+                    It.IsAny<string>(),
+                    It.IsAny<LogContext>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response));
 
             context.RestClient = this.mockRestClient.Object;
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             Assert.AreEqual(Response, context.ResponseContent, "Expected response content to be set.");
 

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/SupplementalDataDeserializerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/SupplementalDataDeserializerTests.cs
@@ -53,7 +53,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 }"
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             const int expectedCount = 0;
             Assert.AreEqual(expectedCount, context.ResultsMeta.SupplementalData.GetAll<TestEntity>().Count,
@@ -74,7 +74,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 }"
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             const int expectedCount = 0;
             Assert.AreEqual(expectedCount, context.ResultsMeta.SupplementalData.GetAll<TestEntity>().Count,
@@ -89,7 +89,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
                 ResponseContent = ResponseContent
             };
 
-            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default).ConfigureAwait(false);
 
             const int expectedGroupItemCount = 2;
             Assert.AreEqual(expectedGroupItemCount, context.ResultsMeta.SupplementalData.GetAll<Group>().Count,

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/UpdateContextValidatorTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/UpdateContextValidatorTests.cs
@@ -45,7 +45,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         {
             var context = new UpdateContext<TestEntity>(EndpointName.Tests, null);
 
-            await this.pipelineElement.ProcessAsync(context, MockLogger.Object)
+            await this.pipelineElement.ProcessAsync(context, MockLogger.Object, default)
                 .ConfigureAwait(false);
         }
 
@@ -55,7 +55,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         {
             var context = new UpdateContext<TestEntity>(EndpointName.Tests, new List<TestEntity>());
 
-            await this.pipelineElement.ProcessAsync(context, MockLogger.Object)
+            await this.pipelineElement.ProcessAsync(context, MockLogger.Object, default)
                 .ConfigureAwait(false);
         }
 

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/UpdateRequestSerializerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/UpdateRequestSerializerTests.cs
@@ -86,7 +86,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         private void AssertSerializesAsExpected<T>(T entityToSerialize, string expectedSerialization)
         {
             UpdateContext<T> context = new UpdateContext<T>(EndpointName.Tests, new[] { entityToSerialize });
-            AsyncUtil.RunSync(() => this.pipelineElement.ProcessAsync(context, NullLogger.Instance));
+            AsyncUtil.RunSync(() => this.pipelineElement.ProcessAsync(context, NullLogger.Instance, default));
 
             TestHelper.AssertJsonEqual(expectedSerialization, context.SerializedRequest);
         }

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/Pipelines/AutoBatchingPipelineTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/Pipelines/AutoBatchingPipelineTests.cs
@@ -22,6 +22,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.Pipelines
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -62,13 +63,14 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.Pipelines
             this.mockInnerPipeline
                 .Setup(h => h.ProcessAsync(
                     It.IsAny<PipelineContext<BasicTestEntity>>(),
-                    It.IsAny<ILogger>()))
-                .Callback((PipelineContext<BasicTestEntity> context, ILogger log) => MockHandleTwoBatches(context))
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback((PipelineContext<BasicTestEntity> context, ILogger log, CancellationToken cancellationToken) => MockHandleTwoBatches(context))
                 .Returns(Task.CompletedTask);
 
             this.pipeline.InnerPipeline = this.mockInnerPipeline.Object;
 
-            await this.pipeline.ProcessAsync(getContext, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipeline.ProcessAsync(getContext, NullLogger.Instance, default).ConfigureAwait(false);
 
             // inner pipeline should have been called twice
             int expectedBatchCount = (int)Math.Ceiling((float)CountOfEntitiesToCreate / MaxBatchSize);

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/Pipelines/AutoPagingPipelineTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/Pipelines/AutoPagingPipelineTests.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.Pipelines
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow;
@@ -51,13 +52,14 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.Pipelines
             this.mockInnerPipeline
                 .Setup(h => h.ProcessAsync(
                     It.IsAny<PipelineContext<BasicTestEntity>>(),
-                    It.IsAny<ILogger>()))
-                .Callback((PipelineContext<BasicTestEntity> context, ILogger log) => MockHandleTwoPages(context))
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback((PipelineContext<BasicTestEntity> context, ILogger log, CancellationToken cancellationToken) => MockHandleTwoPages(context))
                 .Returns(Task.CompletedTask);
 
             this.pipeline.InnerPipeline = this.mockInnerPipeline.Object;
 
-            await this.pipeline.ProcessAsync(getContext, NullLogger.Instance).ConfigureAwait(false);
+            await this.pipeline.ProcessAsync(getContext, NullLogger.Instance, default).ConfigureAwait(false);
 
             // inner pipeline should have been called twice
             const int expectedCount = 2;

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/Pipelines/AutoPagingPipelineTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/Pipelines/AutoPagingPipelineTests.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.Pipelines
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
@@ -73,6 +74,35 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.Pipelines
 
             Assert.AreEqual(expectedCount, getContext.Options.Page,
                 $"Expected final page request to be for page {expectedCount}.");
+        }
+
+        [TestMethod, TestCategory("Unit")]
+        public async Task AutoPagingPipelineTests_ThrowsWhenCancellationIsRequested()
+        {
+            var getContext = new GetContext<BasicTestEntity>(EndpointName.Tests, null, null);
+
+            var tokenSource = new CancellationTokenSource();
+
+            // setup the inner pipeline element to cancel during retrieval of the first page
+            this.mockInnerPipeline
+                .Setup(h => h.ProcessAsync(
+                    It.IsAny<PipelineContext<BasicTestEntity>>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback((PipelineContext<BasicTestEntity> context, ILogger log, CancellationToken cancellationToken) => {
+                    MockHandleTwoPages(context);
+                    tokenSource.Cancel();
+                 })
+                .Returns(Task.CompletedTask);
+
+            this.pipeline.InnerPipeline = this.mockInnerPipeline.Object;
+
+            try
+            {
+                await this.pipeline.ProcessAsync(getContext, NullLogger.Instance, tokenSource.Token).ConfigureAwait(false);
+                Assert.Fail($"Expected {nameof(OperationCanceledException)} to be thrown.");
+            }
+            catch (OperationCanceledException) { }
         }
 
         private static void MockHandleTwoPages(PipelineContext<BasicTestEntity> context)

--- a/Intuit.TSheets/Api/DataService.cs
+++ b/Intuit.TSheets/Api/DataService.cs
@@ -207,7 +207,18 @@ namespace Intuit.TSheets.Api
         {
             string methodType = context.MethodType.ToString().ToUpperInvariant();
 
-            if (ex is ApiException apiEx)
+            if (ex is OperationCanceledException)
+            {
+                logger?.LogDebug(
+                    context.LogContext.EventId,
+                    ex,
+                    "{CorrelationId} {Processor}::{Method}(): {HttpMethod} ERROR",
+                    context.LogContext.CorrelationId,
+                    nameof(DataService),
+                    nameof(ExecuteOperationAsync),
+                    methodType);
+            }
+            else if (ex is ApiException apiEx)
             {
                 logger?.LogError(
                     context.LogContext.EventId,

--- a/Intuit.TSheets/Api/DataService.cs
+++ b/Intuit.TSheets/Api/DataService.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -174,15 +175,20 @@ namespace Intuit.TSheets.Api
         /// </summary>
         /// <typeparam name="T">The entity data type.</typeparam>
         /// <param name="context">Vehicle of state, <see cref="PipelineContext{T}"/></param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The asynchronous task.</returns>
-        internal async Task ExecuteOperationAsync<T>(PipelineContext<T> context)
+        internal async Task ExecuteOperationAsync<T>(
+            PipelineContext<T> context,
+            CancellationToken cancellationToken = default)
         {
             try
             {
                 context.RestClient = this.restClient;
 
                 IPipeline requestPipeline = this.pipelineFactory.GetPipeline(context);
-                await requestPipeline.ProcessAsync(context, this.logger).ConfigureAwait(false);
+                await requestPipeline.ProcessAsync(context, this.logger, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/Intuit.TSheets/Api/DataService.cs
+++ b/Intuit.TSheets/Api/DataService.cs
@@ -181,7 +181,7 @@ namespace Intuit.TSheets.Api
         /// <returns>The asynchronous task.</returns>
         internal async Task ExecuteOperationAsync<T>(
             PipelineContext<T> context,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -194,7 +194,7 @@ namespace Intuit.TSheets.Api
             {
                 LogException(context, ex);
 
-                if (ex is ApiException)
+                if (ex is ApiException || ex is OperationCanceledException)
                 {
                     throw;
                 }

--- a/Intuit.TSheets/Api/DataService_CurrentUser.cs
+++ b/Intuit.TSheets/Api/DataService_CurrentUser.cs
@@ -43,6 +43,23 @@ namespace Intuit.TSheets.Api
         /// Retrieves the user object for the currently authenticated user. This is the
         /// user that authenticated to TSheets during the OAuth2 authentication process.
         /// </remarks>
+        /// <returns>
+        /// An instance of the <see cref="User"/> class, representing the current user, along
+        /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
+        /// data.
+        /// </returns>
+        public (User, ResultsMeta) GetCurrentUser()
+        {
+            return AsyncUtil.RunSync(() => GetCurrentUserAsync());
+        }
+
+        /// <summary>
+        /// Retrieve the Current User.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves the user object for the currently authenticated user. This is the
+        /// user that authenticated to TSheets during the OAuth2 authentication process.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -51,11 +68,29 @@ namespace Intuit.TSheets.Api
         /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
         /// data.
         /// </returns>
-        public (User, ResultsMeta) GetCurrentUser(RequestOptions options = null)
+        public (User, ResultsMeta) GetCurrentUser(
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetCurrentUserAsync(options));
         }
-        
+
+        /// <summary>
+        /// Asynchronously Retrieve the Current User.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves the user object for the currently authenticated user. This is the
+        /// user that authenticated to TSheets during the OAuth2 authentication process.
+        /// </remarks>
+        /// <returns>
+        /// An instance of the <see cref="User"/> class, representing the current user, along
+        /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
+        /// data.
+        /// </returns>
+        public async Task<(User, ResultsMeta)> GetCurrentUserAsync()
+        {
+            return await GetCurrentUserAsync(null).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Asynchronously Retrieve the Current User.
         /// </summary>
@@ -71,7 +106,8 @@ namespace Intuit.TSheets.Api
         /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
         /// data.
         /// </returns>
-        public async Task<(User, ResultsMeta)> GetCurrentUserAsync(RequestOptions options = null)
+        public async Task<(User, ResultsMeta)> GetCurrentUserAsync(
+            RequestOptions options)
         {
             var context = new GetContext<User>(EndpointName.CurrentUser, options);
 

--- a/Intuit.TSheets/Api/DataService_CurrentUser.cs
+++ b/Intuit.TSheets/Api/DataService_CurrentUser.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -92,6 +93,29 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve the Current User, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves the user object for the currently authenticated user. This is the
+        /// user that authenticated to TSheets during the OAuth2 authentication process.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="User"/> class, representing the current user, along
+        /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
+        /// data.
+        /// </returns>
+        public async Task<(User, ResultsMeta)> GetCurrentUserAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve the Current User.
         /// </summary>
         /// <remarks>
@@ -114,6 +138,33 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items.FirstOrDefault(), context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve the Current User, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves the user object for the currently authenticated user. This is the
+        /// user that authenticated to TSheets during the OAuth2 authentication process.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="User"/> class, representing the current user, along
+        /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
+        /// data.
+        /// </returns>
+        public async Task<(User, ResultsMeta)> GetCurrentUserAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_CurrentUser.cs
+++ b/Intuit.TSheets/Api/DataService_CurrentUser.cs
@@ -89,7 +89,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public async Task<(User, ResultsMeta)> GetCurrentUserAsync()
         {
-            return await GetCurrentUserAsync(null).ConfigureAwait(false);
+            return await GetCurrentUserAsync(null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -110,9 +110,7 @@ namespace Intuit.TSheets.Api
         public async Task<(User, ResultsMeta)> GetCurrentUserAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCurrentUserAsync(null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -133,11 +131,7 @@ namespace Intuit.TSheets.Api
         public async Task<(User, ResultsMeta)> GetCurrentUserAsync(
             RequestOptions options)
         {
-            var context = new GetContext<User>(EndpointName.CurrentUser, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items.FirstOrDefault(), context.ResultsMeta);
+            return await GetCurrentUserAsync(options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -162,9 +156,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<User>(EndpointName.CurrentUser, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items.FirstOrDefault(), context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_CustomFieldItemFilters.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItemFilters.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -134,6 +135,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item Filters.
         /// </summary>
         /// <remarks>
@@ -154,6 +177,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item Filters.
         /// </summary>
         /// <remarks>
@@ -171,6 +220,32 @@ namespace Intuit.TSheets.Api
             CustomFieldItemFilterFilter filter)
         {
             return await GetCustomFieldItemFiltersAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
+            CustomFieldItemFilterFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -199,6 +274,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
+            CustomFieldItemFilterFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_CustomFieldItemFilters.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItemFilters.cs
@@ -131,7 +131,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync()
         {
-            return await GetCustomFieldItemFiltersAsync(null, null).ConfigureAwait(false);
+            return await GetCustomFieldItemFiltersAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -151,9 +151,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldItemFiltersAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -173,7 +171,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
             RequestOptions options)
         {
-            return await GetCustomFieldItemFiltersAsync(null, options).ConfigureAwait(false);
+            return await GetCustomFieldItemFiltersAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -197,9 +195,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldItemFiltersAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,7 +215,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
             CustomFieldItemFilterFilter filter)
         {
-            return await GetCustomFieldItemFiltersAsync(filter, null).ConfigureAwait(false);
+            return await GetCustomFieldItemFiltersAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -243,9 +239,7 @@ namespace Intuit.TSheets.Api
             CustomFieldItemFilterFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldItemFiltersAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -269,11 +263,7 @@ namespace Intuit.TSheets.Api
             CustomFieldItemFilterFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<CustomFieldItemFilter>(EndpointName.CustomFieldItemFilters, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetCustomFieldItemFiltersAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,9 +291,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<CustomFieldItemFilter>(EndpointName.CustomFieldItemFilters, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_CustomFieldItemFilters.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItemFilters.cs
@@ -44,6 +44,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
         /// with options to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="Model.CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public (IList<CustomFieldItemFilter>, ResultsMeta) GetCustomFieldItemFilters()
+        {
+            return AsyncUtil.RunSync(() => GetCustomFieldItemFiltersAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Custom Field Item Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -51,9 +67,30 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Model.CustomFieldItemFilter"/> objects retrieved, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public (IList<CustomFieldItemFilter>, ResultsMeta) GetCustomFieldItemFilters(RequestOptions options = null)
+        public (IList<CustomFieldItemFilter>, ResultsMeta) GetCustomFieldItemFilters(
+            RequestOptions options)
         {
-            return GetCustomFieldItemFilters(null, options);
+            return AsyncUtil.RunSync(() => GetCustomFieldItemFiltersAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Custom Field Item Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public (IList<CustomFieldItemFilter>, ResultsMeta) GetCustomFieldItemFilters(
+            CustomFieldItemFilterFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetCustomFieldItemFiltersAsync(filter));
         }
 
         /// <summary>
@@ -75,9 +112,25 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public (IList<CustomFieldItemFilter>, ResultsMeta) GetCustomFieldItemFilters(
             CustomFieldItemFilterFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetCustomFieldItemFiltersAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync()
+        {
+            return await GetCustomFieldItemFiltersAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -95,9 +148,29 @@ namespace Intuit.TSheets.Api
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
         public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return await GetCustomFieldItemFiltersAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
+            CustomFieldItemFilterFilter filter)
+        {
+            return await GetCustomFieldItemFiltersAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -119,7 +192,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public async Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
             CustomFieldItemFilterFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<CustomFieldItemFilter>(EndpointName.CustomFieldItemFilters, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_CustomFieldItemJobcodeFilters.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItemJobcodeFilters.cs
@@ -44,6 +44,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all custom field item filters associated with a user or group,
         /// with options to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public (IList<CustomFieldItemJobcodeFilter>, ResultsMeta) GetCustomFieldItemJobcodeFilters()
+        {
+            return AsyncUtil.RunSync(() => GetCustomFieldItemJobcodeFiltersAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Custom Field Item Jobcode Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -51,9 +67,30 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public (IList<CustomFieldItemJobcodeFilter>, ResultsMeta) GetCustomFieldItemJobcodeFilters(RequestOptions options = null)
+        public (IList<CustomFieldItemJobcodeFilter>, ResultsMeta) GetCustomFieldItemJobcodeFilters(
+            RequestOptions options)
         {
-            return GetCustomFieldItemJobcodeFilters(null, options);
+            return AsyncUtil.RunSync(() => GetCustomFieldItemJobcodeFiltersAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Custom Field Item Jobcode Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemJobcodeFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public (IList<CustomFieldItemJobcodeFilter>, ResultsMeta) GetCustomFieldItemJobcodeFilters(
+            CustomFieldItemJobcodeFilterFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetCustomFieldItemJobcodeFiltersAsync(filter));
         }
 
         /// <summary>
@@ -75,9 +112,25 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public (IList<CustomFieldItemJobcodeFilter>, ResultsMeta) GetCustomFieldItemJobcodeFilters(
             CustomFieldItemJobcodeFilterFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetCustomFieldItemJobcodeFiltersAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync()
+        {
+            return await GetCustomFieldItemJobcodeFiltersAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -95,9 +148,29 @@ namespace Intuit.TSheets.Api
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
         public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return await GetCustomFieldItemJobcodeFiltersAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemJobcodeFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
+            CustomFieldItemJobcodeFilterFilter filter)
+        {
+            return await GetCustomFieldItemJobcodeFiltersAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -119,7 +192,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
             CustomFieldItemJobcodeFilterFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<CustomFieldItemJobcodeFilter>(EndpointName.CustomFieldItemJobcodeFilters, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_CustomFieldItemJobcodeFilters.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItemJobcodeFilters.cs
@@ -131,7 +131,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync()
         {
-            return await GetCustomFieldItemJobcodeFiltersAsync(null, null).ConfigureAwait(false);
+            return await GetCustomFieldItemJobcodeFiltersAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -151,9 +151,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldItemJobcodeFiltersAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -173,7 +171,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
             RequestOptions options)
         {
-            return await GetCustomFieldItemJobcodeFiltersAsync(null, options).ConfigureAwait(false);
+            return await GetCustomFieldItemJobcodeFiltersAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -197,9 +195,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldItemJobcodeFiltersAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,7 +215,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
             CustomFieldItemJobcodeFilterFilter filter)
         {
-            return await GetCustomFieldItemJobcodeFiltersAsync(filter, null).ConfigureAwait(false);
+            return await GetCustomFieldItemJobcodeFiltersAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -243,9 +239,7 @@ namespace Intuit.TSheets.Api
             CustomFieldItemJobcodeFilterFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldItemJobcodeFiltersAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -269,11 +263,7 @@ namespace Intuit.TSheets.Api
             CustomFieldItemJobcodeFilterFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<CustomFieldItemJobcodeFilter>(EndpointName.CustomFieldItemJobcodeFilters, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetCustomFieldItemJobcodeFiltersAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,9 +291,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<CustomFieldItemJobcodeFilter>(EndpointName.CustomFieldItemJobcodeFilters, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_CustomFieldItemJobcodeFilters.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItemJobcodeFilters.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -134,6 +135,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item Jobcode Filters.
         /// </summary>
         /// <remarks>
@@ -154,6 +177,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item Jobcode Filters.
         /// </summary>
         /// <remarks>
@@ -171,6 +220,32 @@ namespace Intuit.TSheets.Api
             CustomFieldItemJobcodeFilterFilter filter)
         {
             return await GetCustomFieldItemJobcodeFiltersAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemJobcodeFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
+            CustomFieldItemJobcodeFilterFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -199,6 +274,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemJobcodeFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
+            CustomFieldItemJobcodeFilterFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_CustomFieldItemUserFilters.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItemUserFilters.cs
@@ -131,7 +131,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync()
         {
-            return await GetCustomFieldItemUserFiltersAsync(null, null).ConfigureAwait(false);
+            return await GetCustomFieldItemUserFiltersAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -151,9 +151,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldItemUserFiltersAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -173,7 +171,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
             RequestOptions options)
         {
-            return await GetCustomFieldItemUserFiltersAsync(null, options).ConfigureAwait(false);
+            return await GetCustomFieldItemUserFiltersAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -195,11 +193,9 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
             RequestOptions options,
-             CancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldItemUserFiltersAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,7 +215,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
             CustomFieldItemUserFilterFilter filter)
         {
-            return await GetCustomFieldItemUserFiltersAsync(filter, null).ConfigureAwait(false);
+            return await GetCustomFieldItemUserFiltersAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -243,9 +239,7 @@ namespace Intuit.TSheets.Api
             CustomFieldItemUserFilterFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldItemUserFiltersAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -269,11 +263,7 @@ namespace Intuit.TSheets.Api
             CustomFieldItemUserFilterFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<CustomFieldItemUserFilter>(EndpointName.CustomFieldItemUserFilters, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetCustomFieldItemUserFiltersAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,9 +291,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<CustomFieldItemUserFilter>(EndpointName.CustomFieldItemUserFilters, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_CustomFieldItemUserFilters.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItemUserFilters.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -134,6 +135,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item User Filters.
         /// </summary>
         /// <remarks>
@@ -154,6 +177,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
+            RequestOptions options,
+             CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item User Filters.
         /// </summary>
         /// <remarks>
@@ -171,6 +220,32 @@ namespace Intuit.TSheets.Api
             CustomFieldItemUserFilterFilter filter)
         {
             return await GetCustomFieldItemUserFiltersAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemUserFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
+            CustomFieldItemUserFilterFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -199,6 +274,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemUserFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
+            CustomFieldItemUserFilterFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_CustomFieldItemUserFilters.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItemUserFilters.cs
@@ -44,6 +44,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all custom field item filters associated with a user or group,
         /// with options to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public (IList<CustomFieldItemUserFilter>, ResultsMeta) GetCustomFieldItemUserFilters()
+        {
+            return AsyncUtil.RunSync(() => GetCustomFieldItemUserFiltersAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Custom Field Item User Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -51,9 +67,30 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public (IList<CustomFieldItemUserFilter>, ResultsMeta) GetCustomFieldItemUserFilters(RequestOptions options = null)
+        public (IList<CustomFieldItemUserFilter>, ResultsMeta) GetCustomFieldItemUserFilters(
+            RequestOptions options)
         {
-            return GetCustomFieldItemUserFilters(null, options);
+            return AsyncUtil.RunSync(() => GetCustomFieldItemUserFiltersAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Custom Field Item User Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemUserFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public (IList<CustomFieldItemUserFilter>, ResultsMeta) GetCustomFieldItemUserFilters(
+            CustomFieldItemUserFilterFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetCustomFieldItemUserFiltersAsync(filter));
         }
 
         /// <summary>
@@ -75,9 +112,25 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public (IList<CustomFieldItemUserFilter>, ResultsMeta) GetCustomFieldItemUserFilters(
             CustomFieldItemUserFilterFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetCustomFieldItemUserFiltersAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync()
+        {
+            return await GetCustomFieldItemUserFiltersAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -95,9 +148,29 @@ namespace Intuit.TSheets.Api
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
         public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return await GetCustomFieldItemUserFiltersAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemUserFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
+            CustomFieldItemUserFilterFilter filter)
+        {
+            return await GetCustomFieldItemUserFiltersAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -119,7 +192,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public async Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
             CustomFieldItemUserFilterFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<CustomFieldItemUserFilter>(EndpointName.CustomFieldItemUserFilters, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_CustomFieldItems.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItems.cs
@@ -42,25 +42,6 @@ namespace Intuit.TSheets.Api
         /// Create Custom Field Items.
         /// </summary>
         /// <remarks>
-        /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
-        /// </remarks>
-        /// <param name="customFieldItems">
-        /// The set of <see cref="CustomFieldItem"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<CustomFieldItem>, ResultsMeta resultsMeta) CreateCustomFieldItems(
-            IEnumerable<CustomFieldItem> customFieldItems)
-        {
-            return AsyncUtil.RunSync(() => CreateCustomFieldItemsAsync(customFieldItems));
-        }
-
-        /// <summary>
-        /// Create Custom Field Items.
-        /// </summary>
-        /// <remarks>
         /// Add a single <see cref="CustomFieldItem"/> object to a <see cref="CustomField"/>.
         /// </remarks>
         /// <param name="customFieldItem">
@@ -79,7 +60,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Custom Field Items.
+        /// Create Custom Field Items.
         /// </summary>
         /// <remarks>
         /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
@@ -91,39 +72,10 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> CreateCustomFieldItemsAsync(
+        public (IList<CustomFieldItem>, ResultsMeta resultsMeta) CreateCustomFieldItems(
             IEnumerable<CustomFieldItem> customFieldItems)
         {
-            var context = new CreateContext<CustomFieldItem>(EndpointName.CustomFieldItems, customFieldItems);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Custom Field Items, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
-        /// </remarks>
-        /// <param name="customFieldItems">
-        /// The set of <see cref="CustomFieldItem"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> CreateCustomFieldItemsAsync(
-            IEnumerable<CustomFieldItem> customFieldItems,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateCustomFieldItemsAsync(customFieldItems));
         }
 
         /// <summary>
@@ -143,7 +95,7 @@ namespace Intuit.TSheets.Api
             CustomFieldItem customFieldItem)
         {
             (IList<CustomFieldItem> customFieldItems, ResultsMeta resultsMeta) =
-                await CreateCustomFieldItemsAsync(new[] { customFieldItem }).ConfigureAwait(false);
+                await CreateCustomFieldItemsAsync(new[] { customFieldItem }, default).ConfigureAwait(false);
 
             return (customFieldItems.FirstOrDefault(), resultsMeta);
         }
@@ -168,9 +120,56 @@ namespace Intuit.TSheets.Api
             CustomFieldItem customFieldItem,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<CustomFieldItem> customFieldItems, ResultsMeta resultsMeta) =
+                await CreateCustomFieldItemsAsync(new[] { customFieldItem }, cancellationToken).ConfigureAwait(false);
+
+            return (customFieldItems.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Custom Field Items.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> CreateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems)
+        {
+            return await CreateCustomFieldItemsAsync(customFieldItems, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> CreateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<CustomFieldItem>(EndpointName.CustomFieldItems, customFieldItems);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -238,7 +237,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomFieldItem>, ResultsMeta)> GetCustomFieldItemsAsync(
             Model.Filters.CustomFieldItemFilter filter)
         {
-            return await GetCustomFieldItemsAsync(filter, null).ConfigureAwait(false);
+            return await GetCustomFieldItemsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -262,9 +261,7 @@ namespace Intuit.TSheets.Api
             Model.Filters.CustomFieldItemFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldItemsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -288,11 +285,7 @@ namespace Intuit.TSheets.Api
             Model.Filters.CustomFieldItemFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<CustomFieldItem>(EndpointName.CustomFieldItems, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetCustomFieldItemsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -320,33 +313,16 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<CustomFieldItem>(EndpointName.CustomFieldItems, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
 
         #region Update Methods
-
-        /// <summary>
-        /// Update Custom Field Items.
-        /// </summary>
-        /// <remarks>
-        /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
-        /// </remarks>
-        /// <param name="customFieldItems">
-        /// The set of <see cref="CustomFieldItem"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<CustomFieldItem>, ResultsMeta resultsMeta) UpdateCustomFieldItems(
-            IEnumerable<CustomFieldItem> customFieldItems)
-        {
-            return AsyncUtil.RunSync(() => UpdateCustomFieldItemsAsync(customFieldItems));
-        }
 
         /// <summary>
         /// Update Custom Field Items.
@@ -371,7 +347,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Update Custom Field Items.
+        /// Update Custom Field Items.
         /// </summary>
         /// <remarks>
         /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
@@ -383,39 +359,10 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> UpdateCustomFieldItemsAsync(
+        public (IList<CustomFieldItem>, ResultsMeta resultsMeta) UpdateCustomFieldItems(
             IEnumerable<CustomFieldItem> customFieldItems)
         {
-            var context = new UpdateContext<CustomFieldItem>(EndpointName.CustomFieldItems, customFieldItems);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Update Custom Field Items, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
-        /// </remarks>
-        /// <param name="customFieldItems">
-        /// The set of <see cref="CustomFieldItem"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> UpdateCustomFieldItemsAsync(
-            IEnumerable<CustomFieldItem> customFieldItems,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => UpdateCustomFieldItemsAsync(customFieldItems));
         }
 
         /// <summary>
@@ -435,7 +382,7 @@ namespace Intuit.TSheets.Api
             CustomFieldItem customFieldItem)
         {
             (IList<CustomFieldItem> customFieldItems, ResultsMeta resultsMeta) =
-                await UpdateCustomFieldItemsAsync(new[] { customFieldItem }).ConfigureAwait(false);
+                await UpdateCustomFieldItemsAsync(new[] { customFieldItem }, default).ConfigureAwait(false);
 
             return (customFieldItems.FirstOrDefault(), resultsMeta);
         }
@@ -460,9 +407,56 @@ namespace Intuit.TSheets.Api
             CustomFieldItem customFieldItem,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<CustomFieldItem> customFieldItems, ResultsMeta resultsMeta) =
+                await UpdateCustomFieldItemsAsync(new[] { customFieldItem }, cancellationToken).ConfigureAwait(false);
+
+            return (customFieldItems.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Custom Field Items.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> UpdateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems)
+        {
+            return await UpdateCustomFieldItemsAsync(customFieldItems, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> UpdateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems,
+            CancellationToken cancellationToken)
+        {
+            var context = new UpdateContext<CustomFieldItem>(EndpointName.CustomFieldItems, customFieldItems);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_CustomFieldItems.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItems.cs
@@ -136,6 +136,26 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="Model.Filters.CustomFieldItemFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public (IList<CustomFieldItem>, ResultsMeta) GetCustomFieldItems(
+            Model.Filters.CustomFieldItemFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetCustomFieldItemsAsync(filter));
+        }
+
+        /// <summary>
+        /// Retrieve Custom Field Items.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field items associated with a custom field,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="Model.Filters.CustomFieldItemFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -145,9 +165,29 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public (IList<CustomFieldItem>, ResultsMeta) GetCustomFieldItems(
             Model.Filters.CustomFieldItemFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetCustomFieldItemsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Items.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field items associated with a custom field,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="Model.Filters.CustomFieldItemFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItem>, ResultsMeta)> GetCustomFieldItemsAsync(
+            Model.Filters.CustomFieldItemFilter filter)
+        {
+            return await GetCustomFieldItemsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -169,7 +209,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public async Task<(IList<CustomFieldItem>, ResultsMeta)> GetCustomFieldItemsAsync(
             Model.Filters.CustomFieldItemFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<CustomFieldItem>(EndpointName.CustomFieldItems, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_CustomFieldItems.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFieldItems.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -101,6 +102,31 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Create Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> CreateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Create Custom Field Items.
         /// </summary>
         /// <remarks>
@@ -120,6 +146,31 @@ namespace Intuit.TSheets.Api
                 await CreateCustomFieldItemsAsync(new[] { customFieldItem }).ConfigureAwait(false);
 
             return (customFieldItems.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single <see cref="CustomFieldItem"/> object to a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItem">
+        /// The <see cref="CustomFieldItem"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="CustomFieldItem"/> object that was created, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(CustomFieldItem, ResultsMeta)> CreateCustomFieldItemAsync(
+            CustomFieldItem customFieldItem,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -191,6 +242,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field items associated with a custom field,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="Model.Filters.CustomFieldItemFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItem>, ResultsMeta)> GetCustomFieldItemsAsync(
+            Model.Filters.CustomFieldItemFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Items.
         /// </summary>
         /// <remarks>
@@ -216,6 +293,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field items associated with a custom field,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="Model.Filters.CustomFieldItemFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItem>, ResultsMeta)> GetCustomFieldItemsAsync(
+            Model.Filters.CustomFieldItemFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -287,6 +394,31 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Update Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> UpdateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Update Custom Field Items.
         /// </summary>
         /// <remarks>
@@ -306,6 +438,31 @@ namespace Intuit.TSheets.Api
                 await UpdateCustomFieldItemsAsync(new[] { customFieldItem }).ConfigureAwait(false);
 
             return (customFieldItems.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single <see cref="CustomFieldItem"/> object to a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItem">
+        /// The <see cref="CustomFieldItem"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="CustomFieldItem"/> object that was updated, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(CustomFieldItem, ResultsMeta)> UpdateCustomFieldItemAsync(
+            CustomFieldItem customFieldItem,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_CustomFields.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFields.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -134,6 +135,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Fields, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Fields.
         /// </summary>
         /// <remarks>
@@ -154,6 +177,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Fields, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Fields.
         /// </summary>
         /// <remarks>
@@ -171,6 +220,32 @@ namespace Intuit.TSheets.Api
             CustomFieldFilter filter)
         {
             return await GetCustomFieldsAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Fields, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
+            CustomFieldFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -199,6 +274,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Fields, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
+            CustomFieldFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_CustomFields.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFields.cs
@@ -44,6 +44,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all custom fields associated with your company,
         /// with filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<CustomField>, ResultsMeta) GetCustomFields()
+        {
+            return AsyncUtil.RunSync(() => GetCustomFieldsAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Custom Fields.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -52,9 +68,29 @@ namespace Intuit.TSheets.Api
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
         public (IList<CustomField>, ResultsMeta) GetCustomFields(
-            RequestOptions options = null)
+            RequestOptions options)
         {
-            return GetCustomFields(null, options);
+            return AsyncUtil.RunSync(() => GetCustomFieldsAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Custom Fields.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<CustomField>, ResultsMeta) GetCustomFields(
+            CustomFieldFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetCustomFieldsAsync(filter));
         }
 
         /// <summary>
@@ -76,9 +112,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<CustomField>, ResultsMeta) GetCustomFields(
             CustomFieldFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetCustomFieldsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Fields.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync()
+        {
+            return await GetCustomFieldsAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -96,9 +148,29 @@ namespace Intuit.TSheets.Api
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
         public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return await GetCustomFieldsAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Fields.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
+            CustomFieldFilter filter)
+        {
+            return await GetCustomFieldsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -120,7 +192,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
             CustomFieldFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<CustomField>(EndpointName.CustomFields, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_CustomFields.cs
+++ b/Intuit.TSheets/Api/DataService_CustomFields.cs
@@ -131,7 +131,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync()
         {
-            return await GetCustomFieldsAsync(null, null).ConfigureAwait(false);
+            return await GetCustomFieldsAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -151,9 +151,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldsAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -173,7 +171,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
             RequestOptions options)
         {
-            return await GetCustomFieldsAsync(null, options).ConfigureAwait(false);
+            return await GetCustomFieldsAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -197,9 +195,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldsAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,7 +215,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
             CustomFieldFilter filter)
         {
-            return await GetCustomFieldsAsync(filter, null).ConfigureAwait(false);
+            return await GetCustomFieldsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -243,9 +239,7 @@ namespace Intuit.TSheets.Api
             CustomFieldFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCustomFieldsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -269,11 +263,7 @@ namespace Intuit.TSheets.Api
             CustomFieldFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<CustomField>(EndpointName.CustomFields, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetCustomFieldsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,9 +291,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<CustomField>(EndpointName.CustomFields, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_EffectiveSettings.cs
+++ b/Intuit.TSheets/Api/DataService_EffectiveSettings.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -86,6 +87,27 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Effective Settings, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all effective settings associated with a single user,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="EffectiveSettings"/> class.
+        /// </returns> 
+        public async Task<EffectiveSettings> GetEffectiveSettingsAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Effective Settings.
         /// </summary>
         /// <remarks>
@@ -98,13 +120,39 @@ namespace Intuit.TSheets.Api
         /// <returns>
         /// An instance of the <see cref="EffectiveSettings"/> class.
         /// </returns> 
-        public async Task<EffectiveSettings> GetEffectiveSettingsAsync(EffectiveSettingsFilter filter)
+        public async Task<EffectiveSettings> GetEffectiveSettingsAsync(
+            EffectiveSettingsFilter filter)
         {
             var context = new GetContext<EffectiveSettings>(EndpointName.EffectiveSettings, filter);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return context.Results.Items.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Effective Settings, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all effective settings associated with a single user,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="EffectiveSettingsFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="EffectiveSettings"/> class.
+        /// </returns> 
+        public async Task<EffectiveSettings> GetEffectiveSettingsAsync(
+            EffectiveSettingsFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_EffectiveSettings.cs
+++ b/Intuit.TSheets/Api/DataService_EffectiveSettings.cs
@@ -83,7 +83,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<EffectiveSettings> GetEffectiveSettingsAsync()
         {
-            return await GetEffectiveSettingsAsync(null).ConfigureAwait(false);
+            return await GetEffectiveSettingsAsync(null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -102,9 +102,7 @@ namespace Intuit.TSheets.Api
         public async Task<EffectiveSettings> GetEffectiveSettingsAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetEffectiveSettingsAsync(null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -123,11 +121,7 @@ namespace Intuit.TSheets.Api
         public async Task<EffectiveSettings> GetEffectiveSettingsAsync(
             EffectiveSettingsFilter filter)
         {
-            var context = new GetContext<EffectiveSettings>(EndpointName.EffectiveSettings, filter);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return context.Results.Items.FirstOrDefault();
+            return await GetEffectiveSettingsAsync(filter, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -150,9 +144,11 @@ namespace Intuit.TSheets.Api
             EffectiveSettingsFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<EffectiveSettings>(EndpointName.EffectiveSettings, filter);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return context.Results.Items.FirstOrDefault();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Files.cs
+++ b/Intuit.TSheets/Api/DataService_Files.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -51,7 +52,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="File"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public (IList<File>, ResultsMeta resultsMeta) UploadFiles(IEnumerable<File> files)
+        public (IList<File>, ResultsMeta resultsMeta) UploadFiles(
+            IEnumerable<File> files)
         {
             return AsyncUtil.RunSync(() => UploadFilesAsync(files));
         }
@@ -69,7 +71,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="CustomFieldItem"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public (File, ResultsMeta) UploadFile(File file)
+        public (File, ResultsMeta) UploadFile(
+            File file)
         {
             (IList<File> files, ResultsMeta resultsMeta) = UploadFiles(new[] { file });
 
@@ -89,13 +92,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="File"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<File>, ResultsMeta)> UploadFilesAsync(IEnumerable<File> files)
+        public async Task<(IList<File>, ResultsMeta)> UploadFilesAsync(
+            IEnumerable<File> files)
         {
             var context = new CreateContext<File>(EndpointName.Files, files);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Upload Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more <see cref="File"/> objects that can be attached to timesheets.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="File"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<File>, ResultsMeta)> UploadFilesAsync(
+            IEnumerable<File> files,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -111,11 +140,38 @@ namespace Intuit.TSheets.Api
         /// The <see cref="CustomFieldItem"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(File, ResultsMeta)> UploadFileAsync(File file)
+        public async Task<(File, ResultsMeta)> UploadFileAsync(
+            File file)
         {
             (IList<File> files, ResultsMeta resultsMeta) = await UploadFilesAsync(new[] { file }).ConfigureAwait(false);
 
             return (files.FirstOrDefault(), resultsMeta);
+        }
+
+
+        /// <summary>
+        /// Asynchronously Upload Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single <see cref="File"/> object that can be attached to a timesheet.
+        /// </remarks>
+        /// <param name="file">
+        /// The set of <see cref="File"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="CustomFieldItem"/> object that was created, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(File, ResultsMeta)> UploadFileAsync(
+            File file,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -219,6 +275,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Files.
         /// </summary>
         /// <remarks>
@@ -239,6 +317,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Files.
         /// </summary>
         /// <remarks>
@@ -256,6 +360,32 @@ namespace Intuit.TSheets.Api
             FileFilter filter)
         {
             return await GetFilesAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="FileFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            FileFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -284,6 +414,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="FileFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            FileFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -342,13 +502,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="File"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(IEnumerable<File> files)
+        public async Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
+            IEnumerable<File> files)
         {
             var context = new UpdateContext<File>(EndpointName.Files, files);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="File"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
+            IEnumerable<File> files,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -364,11 +550,37 @@ namespace Intuit.TSheets.Api
         /// The <see cref="CustomFieldItem"/> object that was updated, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(File, ResultsMeta)> UpdateFileAsync(File file)
+        public async Task<(File, ResultsMeta)> UpdateFileAsync(
+            File file)
         {
             (IList<File> files, ResultsMeta resultsMeta) = await UpdateFilesAsync(new[] { file }).ConfigureAwait(false);
 
             return (files.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Update a single <see cref="File"/> object that is/can be attached to a timesheet.
+        /// </remarks>
+        /// <param name="file">
+        /// The set of <see cref="File"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="CustomFieldItem"/> object that was updated, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(File, ResultsMeta)> UpdateFileAsync(
+            File file,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -390,13 +602,31 @@ namespace Intuit.TSheets.Api
         /// </summary>
         /// <param name="id">The id the of the image file to download.</param>
         /// <returns>An array of bytes, representing the image content.</returns>
-        public async Task<byte[]> DownloadFileAsync(int id)
+        public async Task<byte[]> DownloadFileAsync(
+            int id)
         {
             var context = new DownloadContext<File>(EndpointName.FilesRaw, new FileDownloadFilter(id));
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return context.RawResponseContent;
+        }
+
+        /// <summary>
+        /// Asynchronously download the raw bytes of an image file, with support for cancellation.
+        /// </summary>
+        /// <param name="id">The id the of the image file to download.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>An array of bytes, representing the image content.</returns>
+        public async Task<byte[]> DownloadFileAsync(
+            int id,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -471,9 +701,32 @@ namespace Intuit.TSheets.Api
         /// The <see cref="File"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteFileAsync(File file)
+        public async Task DeleteFileAsync(
+            File file)
         {
             await DeleteFilesAsync(new[] { file }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="File"/> object.
+        /// </remarks>
+        /// <param name="file">
+        /// The <see cref="File"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteFileAsync(
+            File file,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -486,11 +739,34 @@ namespace Intuit.TSheets.Api
         /// The set of <see cref="File"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteFilesAsync(IEnumerable<File> files)
+        public async Task DeleteFilesAsync(
+            IEnumerable<File> files)
         {
             IEnumerable<int> ids = files?.Select(t => t.Id);
 
             await DeleteFilesAsync(ids).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="File"/> objects.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteFilesAsync(
+            IEnumerable<File> files,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -503,9 +779,32 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="File"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteFileAsync(int id)
+        public async Task DeleteFileAsync(
+            int id)
         {
             await DeleteFilesAsync(new[] { id }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="File"/> object, by id.
+        /// </remarks>
+        /// <param name="id">
+        /// The id of the <see cref="File"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteFileAsync(
+            int id,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -518,11 +817,34 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="File"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteFilesAsync(IEnumerable<int> ids)
+        public async Task DeleteFilesAsync(
+            IEnumerable<int> ids)
         {
             var context = new DeleteContext<File>(EndpointName.Files, ids);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="File"/> objects, by id.
+        /// </remarks>
+        /// <param name="ids">
+        /// The set of ids for the <see cref="File"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteFilesAsync(
+            IEnumerable<int> ids,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Files.cs
+++ b/Intuit.TSheets/Api/DataService_Files.cs
@@ -129,6 +129,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all uploaded files, with
         /// optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<File>, ResultsMeta) GetFiles()
+        {
+            return AsyncUtil.RunSync(() => GetFilesAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Files.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -136,9 +152,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="File"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public (IList<File>, ResultsMeta) GetFiles(RequestOptions options = null)
+        public (IList<File>, ResultsMeta) GetFiles(
+            RequestOptions options)
         {
-            return GetFiles(null, options);
+            return AsyncUtil.RunSync(() => GetFilesAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Files.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="FileFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<File>, ResultsMeta) GetFiles(
+            FileFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetFilesAsync(filter));
         }
 
         /// <summary>
@@ -160,9 +197,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<File>, ResultsMeta) GetFiles(
             FileFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetFilesAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Files.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<File>, ResultsMeta)> GetFilesAsync()
+        {
+            return await GetFilesAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -179,9 +232,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="File"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public async Task<(IList<File>, ResultsMeta)> GetFilesAsync(RequestOptions options = null)
+        public async Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            RequestOptions options)
         {
             return await GetFilesAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Files.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="FileFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            FileFilter filter)
+        {
+            return await GetFilesAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -203,7 +277,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<File>, ResultsMeta)> GetFilesAsync(
             FileFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<File>(EndpointName.Files, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_Files.cs
+++ b/Intuit.TSheets/Api/DataService_Files.cs
@@ -43,25 +43,6 @@ namespace Intuit.TSheets.Api
         /// Upload Files.
         /// </summary>
         /// <remarks>
-        /// Add one or more <see cref="File"/> objects that can be attached to timesheets.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="File"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<File>, ResultsMeta resultsMeta) UploadFiles(
-            IEnumerable<File> files)
-        {
-            return AsyncUtil.RunSync(() => UploadFilesAsync(files));
-        }
-
-        /// <summary>
-        /// Upload Files.
-        /// </summary>
-        /// <remarks>
         /// Add a single <see cref="File"/> object that can be attached to a timesheet.
         /// </remarks>
         /// <param name="file">
@@ -80,7 +61,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Upload Files.
+        /// Upload Files.
         /// </summary>
         /// <remarks>
         /// Add one or more <see cref="File"/> objects that can be attached to timesheets.
@@ -92,39 +73,10 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="File"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<File>, ResultsMeta)> UploadFilesAsync(
+        public (IList<File>, ResultsMeta resultsMeta) UploadFiles(
             IEnumerable<File> files)
         {
-            var context = new CreateContext<File>(EndpointName.Files, files);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Upload Files, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more <see cref="File"/> objects that can be attached to timesheets.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="File"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<File>, ResultsMeta)> UploadFilesAsync(
-            IEnumerable<File> files,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => UploadFilesAsync(files));
         }
 
         /// <summary>
@@ -143,7 +95,7 @@ namespace Intuit.TSheets.Api
         public async Task<(File, ResultsMeta)> UploadFileAsync(
             File file)
         {
-            (IList<File> files, ResultsMeta resultsMeta) = await UploadFilesAsync(new[] { file }).ConfigureAwait(false);
+            (IList<File> files, ResultsMeta resultsMeta) = await UploadFilesAsync(new[] { file }, default).ConfigureAwait(false);
 
             return (files.FirstOrDefault(), resultsMeta);
         }
@@ -169,9 +121,55 @@ namespace Intuit.TSheets.Api
             File file,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<File> files, ResultsMeta resultsMeta) = await UploadFilesAsync(new[] { file }, cancellationToken).ConfigureAwait(false);
+
+            return (files.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Upload Files.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more <see cref="File"/> objects that can be attached to timesheets.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="File"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<File>, ResultsMeta)> UploadFilesAsync(
+            IEnumerable<File> files)
+        {
+            return await UploadFilesAsync(files, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Upload Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more <see cref="File"/> objects that can be attached to timesheets.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="File"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<File>, ResultsMeta)> UploadFilesAsync(
+            IEnumerable<File> files,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<File>(EndpointName.Files, files);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -271,7 +269,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<File>, ResultsMeta)> GetFilesAsync()
         {
-            return await GetFilesAsync(null, null).ConfigureAwait(false);
+            return await GetFilesAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -291,9 +289,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<File>, ResultsMeta)> GetFilesAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetFilesAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -313,7 +309,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<File>, ResultsMeta)> GetFilesAsync(
             RequestOptions options)
         {
-            return await GetFilesAsync(null, options).ConfigureAwait(false);
+            return await GetFilesAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -337,9 +333,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetFilesAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -359,7 +353,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<File>, ResultsMeta)> GetFilesAsync(
             FileFilter filter)
         {
-            return await GetFilesAsync(filter, null).ConfigureAwait(false);
+            return await GetFilesAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -383,9 +377,7 @@ namespace Intuit.TSheets.Api
             FileFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetFilesAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -409,11 +401,7 @@ namespace Intuit.TSheets.Api
             FileFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<File>(EndpointName.Files, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetFilesAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -441,33 +429,16 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<File>(EndpointName.Files, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
 
         #region Update Methods
-
-        /// <summary>
-        /// Update Files.
-        /// </summary>
-        /// <remarks>
-        /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="File"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<File>, ResultsMeta resultsMeta) UpdateFiles(
-            IEnumerable<File> files)
-        {
-            return AsyncUtil.RunSync(() => UpdateFilesAsync(files));
-        }
 
         /// <summary>
         /// Update Files.
@@ -490,7 +461,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Update Files.
+        /// Update Files.
         /// </summary>
         /// <remarks>
         /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
@@ -502,39 +473,10 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="File"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
+        public (IList<File>, ResultsMeta resultsMeta) UpdateFiles(
             IEnumerable<File> files)
         {
-            var context = new UpdateContext<File>(EndpointName.Files, files);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Update Files, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="File"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
-            IEnumerable<File> files,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => UpdateFilesAsync(files));
         }
 
         /// <summary>
@@ -553,7 +495,7 @@ namespace Intuit.TSheets.Api
         public async Task<(File, ResultsMeta)> UpdateFileAsync(
             File file)
         {
-            (IList<File> files, ResultsMeta resultsMeta) = await UpdateFilesAsync(new[] { file }).ConfigureAwait(false);
+            (IList<File> files, ResultsMeta resultsMeta) = await UpdateFilesAsync(new[] { file }, default).ConfigureAwait(false);
 
             return (files.FirstOrDefault(), resultsMeta);
         }
@@ -578,9 +520,55 @@ namespace Intuit.TSheets.Api
             File file,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<File> files, ResultsMeta resultsMeta) = await UpdateFilesAsync(new[] { file }, cancellationToken).ConfigureAwait(false);
+
+            return (files.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Files.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="File"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
+            IEnumerable<File> files)
+        {
+            return await UpdateFilesAsync(files, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="File"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
+            IEnumerable<File> files,
+            CancellationToken cancellationToken)
+        {
+            var context = new UpdateContext<File>(EndpointName.Files, files);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -605,11 +593,7 @@ namespace Intuit.TSheets.Api
         public async Task<byte[]> DownloadFileAsync(
             int id)
         {
-            var context = new DownloadContext<File>(EndpointName.FilesRaw, new FileDownloadFilter(id));
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return context.RawResponseContent;
+            return await DownloadFileAsync(id, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -624,9 +608,11 @@ namespace Intuit.TSheets.Api
             int id,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new DownloadContext<File>(EndpointName.FilesRaw, new FileDownloadFilter(id));
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return context.RawResponseContent;
         }
 
         #endregion
@@ -644,23 +630,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         public void DeleteFile(File file)
         {
-            DeleteFiles(new[] { file });
-        }
-        
-        /// <summary>
-        /// Delete Files.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="File"/> objects.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be deleted.
-        /// </param>
-        public void DeleteFiles(IEnumerable<File> files)
-        {
-            IEnumerable<int> ids = files?.Select(j => j.Id);
-
-            DeleteFiles(ids);
+            AsyncUtil.RunSync(() => DeleteFileAsync(file));
         }
 
         /// <summary>
@@ -674,7 +644,21 @@ namespace Intuit.TSheets.Api
         /// </param>
         public void DeleteFile(int id)
         {
-            DeleteFiles(new[] { id });
+            AsyncUtil.RunSync(() => DeleteFileAsync(id));
+        }
+
+        /// <summary>
+        /// Delete Files.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="File"/> objects.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be deleted.
+        /// </param>
+        public void DeleteFiles(IEnumerable<File> files)
+        {
+            AsyncUtil.RunSync(() => DeleteFilesAsync(files));
         }
 
         /// <summary>
@@ -704,7 +688,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteFileAsync(
             File file)
         {
-            await DeleteFilesAsync(new[] { file }).ConfigureAwait(false);
+            await DeleteFilesAsync(new[] { file.Id }, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -724,49 +708,7 @@ namespace Intuit.TSheets.Api
             File file,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
-        }
-
-        /// <summary>
-        /// Asynchronously Delete Files.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="File"/> objects.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be deleted.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        public async Task DeleteFilesAsync(
-            IEnumerable<File> files)
-        {
-            IEnumerable<int> ids = files?.Select(t => t.Id);
-
-            await DeleteFilesAsync(ids).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Asynchronously Delete Files, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="File"/> objects.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be deleted.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        public async Task DeleteFilesAsync(
-            IEnumerable<File> files,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            await DeleteFilesAsync(new[] { file.Id }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -782,7 +724,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteFileAsync(
             int id)
         {
-            await DeleteFilesAsync(new[] { id }).ConfigureAwait(false);
+            await DeleteFilesAsync(new[] { id }, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -802,9 +744,47 @@ namespace Intuit.TSheets.Api
             int id,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            await DeleteFilesAsync(new[] { id }, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Files.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="File"/> objects.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be deleted.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteFilesAsync(
+            IEnumerable<File> files)
+        {
+            IEnumerable<int> ids = files?.Select(t => t.Id);
+
+            await DeleteFilesAsync(ids, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="File"/> objects.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteFilesAsync(
+            IEnumerable<File> files,
+            CancellationToken cancellationToken)
+        {
+            IEnumerable<int> ids = files?.Select(t => t.Id);
+
+            await DeleteFilesAsync(ids, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -820,9 +800,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteFilesAsync(
             IEnumerable<int> ids)
         {
-            var context = new DeleteContext<File>(EndpointName.Files, ids);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
+            await DeleteFilesAsync(ids, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -842,9 +820,9 @@ namespace Intuit.TSheets.Api
             IEnumerable<int> ids,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new DeleteContext<File>(EndpointName.Files, ids);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_GeofenceConfigs.cs
+++ b/Intuit.TSheets/Api/DataService_GeofenceConfigs.cs
@@ -131,7 +131,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync()
         {
-            return await GetGeofenceConfigsAsync(null, null).ConfigureAwait(false);
+            return await GetGeofenceConfigsAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -151,9 +151,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetGeofenceConfigsAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -173,7 +171,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
             RequestOptions options)
         {
-            return await GetGeofenceConfigsAsync(null, options).ConfigureAwait(false);
+            return await GetGeofenceConfigsAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -197,9 +195,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetGeofenceConfigsAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,7 +215,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
             GeofenceConfigFilter filter)
         {
-            return await GetGeofenceConfigsAsync(filter, null).ConfigureAwait(false);
+            return await GetGeofenceConfigsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -243,9 +239,7 @@ namespace Intuit.TSheets.Api
             GeofenceConfigFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetGeofenceConfigsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -269,11 +263,7 @@ namespace Intuit.TSheets.Api
             GeofenceConfigFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<GeofenceConfig>(EndpointName.GeofenceConfigs, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetGeofenceConfigsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,9 +291,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<GeofenceConfig>(EndpointName.GeofenceConfigs, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_GeofenceConfigs.cs
+++ b/Intuit.TSheets/Api/DataService_GeofenceConfigs.cs
@@ -44,6 +44,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all geofence configurations, with
         /// optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<GeofenceConfig>, ResultsMeta) GetGeofenceConfigs()
+        {
+            return AsyncUtil.RunSync(() => GetGeofenceConfigsAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Geofence Configurations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -51,9 +67,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public (IList<GeofenceConfig>, ResultsMeta) GetGeofenceConfigs(RequestOptions options = null)
+        public (IList<GeofenceConfig>, ResultsMeta) GetGeofenceConfigs(
+            RequestOptions options)
         {
-            return GetGeofenceConfigs(null, options);
+            return AsyncUtil.RunSync(() => GetGeofenceConfigsAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Geofence Configurations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeofenceConfigFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<GeofenceConfig>, ResultsMeta) GetGeofenceConfigs(
+            GeofenceConfigFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetGeofenceConfigsAsync(filter));
         }
 
         /// <summary>
@@ -75,9 +112,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<GeofenceConfig>, ResultsMeta) GetGeofenceConfigs(
             GeofenceConfigFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetGeofenceConfigsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync()
+        {
+            return await GetGeofenceConfigsAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -94,9 +147,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(RequestOptions options = null)
+        public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            RequestOptions options)
         {
             return await GetGeofenceConfigsAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeofenceConfigFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            GeofenceConfigFilter filter)
+        {
+            return await GetGeofenceConfigsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -118,7 +192,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
             GeofenceConfigFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<GeofenceConfig>(EndpointName.GeofenceConfigs, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_GeofenceConfigs.cs
+++ b/Intuit.TSheets/Api/DataService_GeofenceConfigs.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -134,6 +135,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Geofence Configurations.
         /// </summary>
         /// <remarks>
@@ -154,6 +177,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Geofence Configurations.
         /// </summary>
         /// <remarks>
@@ -171,6 +220,32 @@ namespace Intuit.TSheets.Api
             GeofenceConfigFilter filter)
         {
             return await GetGeofenceConfigsAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeofenceConfigFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            GeofenceConfigFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -199,6 +274,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeofenceConfigFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            GeofenceConfigFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Geolocations.cs
+++ b/Intuit.TSheets/Api/DataService_Geolocations.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -80,13 +81,36 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Geolocation"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(IEnumerable<Geolocation> geolocations)
+        public async Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
+            IEnumerable<Geolocation> geolocations)
         {
             var context = new CreateContext<Geolocation>(EndpointName.Geolocations, geolocations);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Geolocations, with support for cancellation.
+        /// </summary>
+        /// <param name="geolocations">
+        /// The set of <see cref="Geolocation"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Geolocation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
+            IEnumerable<Geolocation> geolocations,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -99,11 +123,34 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Geolocation"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Geolocation, ResultsMeta)> CreateGeolocationAsync(Geolocation geolocation)
+        public async Task<(Geolocation, ResultsMeta)> CreateGeolocationAsync(
+            Geolocation geolocation)
         {
             (IList<Geolocation> geolocations, ResultsMeta resultsMeta) = await CreateGeolocationsAsync(new[] { geolocation }).ConfigureAwait(false);
 
             return (geolocations.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Geolocations, with support for cancellation.
+        /// </summary>
+        /// <param name="geolocation">
+        /// The <see cref="Geolocation"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Geolocation"/> object that was created, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Geolocation, ResultsMeta)> CreateGeolocationAsync(
+            Geolocation geolocation,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -175,6 +222,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Geolocations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of geolocations associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeolocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Geolocation"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Geolocation>, ResultsMeta)> GetGeolocationsAsync(
+            GeolocationFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Geolocations.
         /// </summary>
         /// <remarks>
@@ -200,6 +273,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Geolocations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of geolocations associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeolocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Geolocation"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Geolocation>, ResultsMeta)> GetGeolocationsAsync(
+            GeolocationFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Geolocations.cs
+++ b/Intuit.TSheets/Api/DataService_Geolocations.cs
@@ -42,21 +42,6 @@ namespace Intuit.TSheets.Api
         /// <summary>
         /// Create Geolocations.
         /// </summary>
-        /// <param name="geolocations">
-        /// The set of <see cref="Geolocation"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Geolocation"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Geolocation>, ResultsMeta) CreateGeolocations(IEnumerable<Geolocation> geolocations)
-        {
-            return AsyncUtil.RunSync(() => CreateGeolocationsAsync(geolocations));
-        }
-
-        /// <summary>
-        /// Create Geolocations.
-        /// </summary>
         /// <param name="geolocation">
         /// The <see cref="Geolocation"/> object to be created.
         /// </param>
@@ -72,7 +57,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Geolocations.
+        /// Create Geolocations.
         /// </summary>
         /// <param name="geolocations">
         /// The set of <see cref="Geolocation"/> objects to be created.
@@ -81,36 +66,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Geolocation"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
-            IEnumerable<Geolocation> geolocations)
+        public (IList<Geolocation>, ResultsMeta) CreateGeolocations(IEnumerable<Geolocation> geolocations)
         {
-            var context = new CreateContext<Geolocation>(EndpointName.Geolocations, geolocations);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Geolocations, with support for cancellation.
-        /// </summary>
-        /// <param name="geolocations">
-        /// The set of <see cref="Geolocation"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Geolocation"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
-            IEnumerable<Geolocation> geolocations,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateGeolocationsAsync(geolocations));
         }
 
         /// <summary>
@@ -126,7 +84,7 @@ namespace Intuit.TSheets.Api
         public async Task<(Geolocation, ResultsMeta)> CreateGeolocationAsync(
             Geolocation geolocation)
         {
-            (IList<Geolocation> geolocations, ResultsMeta resultsMeta) = await CreateGeolocationsAsync(new[] { geolocation }).ConfigureAwait(false);
+            (IList<Geolocation> geolocations, ResultsMeta resultsMeta) = await CreateGeolocationsAsync(new[] { geolocation }, default).ConfigureAwait(false);
 
             return (geolocations.FirstOrDefault(), resultsMeta);
         }
@@ -148,9 +106,49 @@ namespace Intuit.TSheets.Api
             Geolocation geolocation,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Geolocation> geolocations, ResultsMeta resultsMeta) = await CreateGeolocationsAsync(new[] { geolocation }, cancellationToken).ConfigureAwait(false);
+
+            return (geolocations.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Geolocations.
+        /// </summary>
+        /// <param name="geolocations">
+        /// The set of <see cref="Geolocation"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Geolocation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
+            IEnumerable<Geolocation> geolocations)
+        {
+            return await CreateGeolocationsAsync(geolocations, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Geolocations, with support for cancellation.
+        /// </summary>
+        /// <param name="geolocations">
+        /// The set of <see cref="Geolocation"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Geolocation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
+            IEnumerable<Geolocation> geolocations,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<Geolocation>(EndpointName.Geolocations, geolocations);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -218,7 +216,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Geolocation>, ResultsMeta)> GetGeolocationsAsync(
             GeolocationFilter filter)
         {
-            return await GetGeolocationsAsync(filter, null).ConfigureAwait(false);
+            return await GetGeolocationsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -242,9 +240,7 @@ namespace Intuit.TSheets.Api
             GeolocationFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetGeolocationsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -268,11 +264,7 @@ namespace Intuit.TSheets.Api
             GeolocationFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<Geolocation>(EndpointName.Geolocations, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetGeolocationsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -300,9 +292,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<Geolocation>(EndpointName.Geolocations, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Geolocations.cs
+++ b/Intuit.TSheets/Api/DataService_Geolocations.cs
@@ -120,6 +120,26 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="GeolocationFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Geolocation"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<Geolocation>, ResultsMeta) GetGeolocations(
+            GeolocationFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetGeolocationsAsync(filter));
+        }
+
+        /// <summary>
+        /// Retrieve Geolocations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of geolocations associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeolocationFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -129,9 +149,29 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<Geolocation>, ResultsMeta) GetGeolocations(
             GeolocationFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetGeolocationsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Geolocations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of geolocations associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeolocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Geolocation"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Geolocation>, ResultsMeta)> GetGeolocationsAsync(
+            GeolocationFilter filter)
+        {
+            return await GetGeolocationsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -153,7 +193,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<Geolocation>, ResultsMeta)> GetGeolocationsAsync(
             GeolocationFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<Geolocation>(EndpointName.Geolocations, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_Groups.cs
+++ b/Intuit.TSheets/Api/DataService_Groups.cs
@@ -43,24 +43,6 @@ namespace Intuit.TSheets.Api
         /// Create Groups.
         /// </summary>
         /// <remarks>
-        /// Add one or more groups to your company.
-        /// </remarks>
-        /// <param name="groups">
-        /// The set of <see cref="Group"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Group"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Group>, ResultsMeta) CreateGroups(IEnumerable<Group> groups)
-        {
-            return AsyncUtil.RunSync(() => CreateGroupsAsync(groups));
-        }
-
-        /// <summary>
-        /// Create Groups.
-        /// </summary>
-        /// <remarks>
         /// Add a single group to your company.
         /// </remarks> 
         /// <param name="group">
@@ -78,7 +60,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Groups.
+        /// Create Groups.
         /// </summary>
         /// <remarks>
         /// Add one or more groups to your company.
@@ -90,39 +72,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Group"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
-            IEnumerable<Group> groups)
+        public (IList<Group>, ResultsMeta) CreateGroups(IEnumerable<Group> groups)
         {
-            var context = new CreateContext<Group>(EndpointName.Groups, groups);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Groups, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more groups to your company.
-        /// </remarks>
-        /// <param name="groups">
-        /// The set of <see cref="Group"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Group"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
-            IEnumerable<Group> groups,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateGroupsAsync(groups));
         }
 
         /// <summary>
@@ -141,7 +93,7 @@ namespace Intuit.TSheets.Api
         public async Task<(Group, ResultsMeta)> CreateGroupAsync(
             Group group)
         {
-            (IList<Group> groups, ResultsMeta resultsMeta) = await CreateGroupsAsync(new[] { group }).ConfigureAwait(false);
+            (IList<Group> groups, ResultsMeta resultsMeta) = await CreateGroupsAsync(new[] { group }, default).ConfigureAwait(false);
 
             return (groups.FirstOrDefault(), resultsMeta);
         }
@@ -166,9 +118,55 @@ namespace Intuit.TSheets.Api
             Group group,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Group> groups, ResultsMeta resultsMeta) = await CreateGroupsAsync(new[] { group }, cancellationToken).ConfigureAwait(false);
+
+            return (groups.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Groups.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more groups to your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
+            IEnumerable<Group> groups)
+        {
+            return await CreateGroupsAsync(groups, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more groups to your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
+            IEnumerable<Group> groups,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<Group>(EndpointName.Groups, groups);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -268,7 +266,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync()
         {
-            return await GetGroupsAsync(null, null).ConfigureAwait(false);
+            return await GetGroupsAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -288,9 +286,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetGroupsAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -310,7 +306,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
             RequestOptions options)
         {
-            return await GetGroupsAsync(null, options).ConfigureAwait(false);
+            return await GetGroupsAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -334,9 +330,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetGroupsAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -356,7 +350,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
             GroupFilter filter)
         {
-            return await GetGroupsAsync(filter, null).ConfigureAwait(false);
+            return await GetGroupsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -380,9 +374,7 @@ namespace Intuit.TSheets.Api
             GroupFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetGroupsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -406,11 +398,7 @@ namespace Intuit.TSheets.Api
             GroupFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<Group>(EndpointName.Groups, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetGroupsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -438,32 +426,16 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<Group>(EndpointName.Groups, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
 
         #region Update Methods
-
-        /// <summary>
-        /// Update Groups.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more groups in your company.
-        /// </remarks>
-        /// <param name="groups">
-        /// The set of <see cref="Group"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Group"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Group>, ResultsMeta) UpdateGroups(IEnumerable<Group> groups)
-        {
-            return AsyncUtil.RunSync(() => UpdateGroupsAsync(groups));
-        }
 
         /// <summary>
         /// Update Groups.
@@ -486,7 +458,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Update Groups.
+        /// Update Groups.
         /// </summary>
         /// <remarks>
         /// Edit one or more groups in your company.
@@ -498,39 +470,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Group"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
-            IEnumerable<Group> groups)
+        public (IList<Group>, ResultsMeta) UpdateGroups(IEnumerable<Group> groups)
         {
-            var context = new UpdateContext<Group>(EndpointName.Groups, groups);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Update Groups, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more groups in your company.
-        /// </remarks>
-        /// <param name="groups">
-        /// The set of <see cref="Group"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Group"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
-            IEnumerable<Group> groups,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => UpdateGroupsAsync(groups));
         }
 
         /// <summary>
@@ -550,7 +492,7 @@ namespace Intuit.TSheets.Api
             Group group)
         {
             (IList<Group> groups, ResultsMeta resultsMeta) =
-                await UpdateGroupsAsync(new[] { group }).ConfigureAwait(false);
+                await UpdateGroupsAsync(new[] { group }, default).ConfigureAwait(false);
 
             return (groups.FirstOrDefault(), resultsMeta);
         }
@@ -575,9 +517,56 @@ namespace Intuit.TSheets.Api
             Group group,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Group> groups, ResultsMeta resultsMeta) =
+                await UpdateGroupsAsync(new[] { group }, cancellationToken).ConfigureAwait(false);
+
+            return (groups.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Groups.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more groups in your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
+            IEnumerable<Group> groups)
+        {
+            return await UpdateGroupsAsync(groups, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more groups in your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
+            IEnumerable<Group> groups,
+            CancellationToken cancellationToken)
+        {
+            var context = new UpdateContext<Group>(EndpointName.Groups, groups);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Groups.cs
+++ b/Intuit.TSheets/Api/DataService_Groups.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -89,13 +90,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Group"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(IEnumerable<Group> groups)
+        public async Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
+            IEnumerable<Group> groups)
         {
             var context = new CreateContext<Group>(EndpointName.Groups, groups);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more groups to your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
+            IEnumerable<Group> groups,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -111,11 +138,37 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Group"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Group, ResultsMeta)> CreateGroupAsync(Group group)
+        public async Task<(Group, ResultsMeta)> CreateGroupAsync(
+            Group group)
         {
             (IList<Group> groups, ResultsMeta resultsMeta) = await CreateGroupsAsync(new[] { group }).ConfigureAwait(false);
 
             return (groups.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single group to your company.
+        /// </remarks>
+        /// <param name="group">
+        /// The <see cref="Group"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Group"/> object that was created, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Group, ResultsMeta)> CreateGroupAsync(
+            Group group,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -219,6 +272,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Groups.
         /// </summary>
         /// <remarks>
@@ -239,6 +314,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Groups.
         /// </summary>
         /// <remarks>
@@ -256,6 +357,32 @@ namespace Intuit.TSheets.Api
             GroupFilter filter)
         {
             return await GetGroupsAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GroupFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            GroupFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -284,6 +411,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GroupFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            GroupFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -341,13 +498,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Group"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(IEnumerable<Group> groups)
+        public async Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
+            IEnumerable<Group> groups)
         {
             var context = new UpdateContext<Group>(EndpointName.Groups, groups);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more groups in your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
+            IEnumerable<Group> groups,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -363,12 +546,38 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Group"/> object that was updated, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Group, ResultsMeta)> UpdateGroupAsync(Group group)
+        public async Task<(Group, ResultsMeta)> UpdateGroupAsync(
+            Group group)
         {
             (IList<Group> groups, ResultsMeta resultsMeta) =
                 await UpdateGroupsAsync(new[] { group }).ConfigureAwait(false);
 
             return (groups.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single group in your company.
+        /// </remarks>
+        /// <param name="group">
+        /// The <see cref="Group"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Group"/> object that was updated, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Group, ResultsMeta)> UpdateGroupAsync(
+            Group group,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Groups.cs
+++ b/Intuit.TSheets/Api/DataService_Groups.cs
@@ -129,6 +129,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of groups associated with your company, with
         /// optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<Group>, ResultsMeta) GetGroups()
+        {
+            return AsyncUtil.RunSync(() => GetGroupsAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Groups.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -136,9 +152,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Group"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public (IList<Group>, ResultsMeta) GetGroups(RequestOptions options = null)
+        public (IList<Group>, ResultsMeta) GetGroups(
+            RequestOptions options)
         {
-            return GetGroups(null, options);
+            return AsyncUtil.RunSync(() => GetGroupsAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Groups.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GroupFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<Group>, ResultsMeta) GetGroups(
+            GroupFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetGroupsAsync(filter));
         }
 
         /// <summary>
@@ -160,9 +197,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<Group>, ResultsMeta) GetGroups(
             GroupFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetGroupsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Groups.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync()
+        {
+            return await GetGroupsAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -179,9 +232,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Group"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(RequestOptions options = null)
+        public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            RequestOptions options)
         {
             return await GetGroupsAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Groups.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GroupFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            GroupFilter filter)
+        {
+            return await GetGroupsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -203,7 +277,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
             GroupFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<Group>(EndpointName.Groups, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_Invitations.cs
+++ b/Intuit.TSheets/Api/DataService_Invitations.cs
@@ -42,24 +42,6 @@ namespace Intuit.TSheets.Api
         /// Create Invitations.
         /// </summary>
         /// <remarks>
-        /// Invite one or more users to your company.
-        /// </remarks>
-        /// <param name="invitations">
-        /// The set of <see cref="Invitation"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Invitation"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Invitation>, ResultsMeta) CreateInvitations(IEnumerable<Invitation> invitations)
-        {
-            return AsyncUtil.RunSync(() => CreateInvitationsAsync(invitations));
-        }
-
-        /// <summary>
-        /// Create Invitations.
-        /// </summary>
-        /// <remarks>
         /// Invite a single user to your company.
         /// </remarks> 
         /// <param name="invitation">
@@ -77,7 +59,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Invitations.
+        /// Create Invitations.
         /// </summary>
         /// <remarks>
         /// Invite one or more users to your company.
@@ -89,39 +71,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Invitation"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
-            IEnumerable<Invitation> invitations)
+        public (IList<Invitation>, ResultsMeta) CreateInvitations(IEnumerable<Invitation> invitations)
         {
-            var context = new CreateContext<Invitation>(EndpointName.Invitations, invitations);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Invitations, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Invite one or more users to your company.
-        /// </remarks>
-        /// <param name="invitations">
-        /// The set of <see cref="Invitation"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Invitation"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
-            IEnumerable<Invitation> invitations,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateInvitationsAsync(invitations));
         }
 
         /// <summary>
@@ -140,7 +92,7 @@ namespace Intuit.TSheets.Api
         public async Task<(Invitation, ResultsMeta)> CreateInvitationAsync(
             Invitation invitation)
         {
-            (IList<Invitation> invitations, ResultsMeta resultsMeta) = await CreateInvitationsAsync(new[] { invitation }).ConfigureAwait(false);
+            (IList<Invitation> invitations, ResultsMeta resultsMeta) = await CreateInvitationsAsync(new[] { invitation }, default).ConfigureAwait(false);
 
             return (invitations.FirstOrDefault(), resultsMeta);
         }
@@ -165,9 +117,55 @@ namespace Intuit.TSheets.Api
             Invitation invitation,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Invitation> invitations, ResultsMeta resultsMeta) = await CreateInvitationsAsync(new[] { invitation }, cancellationToken).ConfigureAwait(false);
+
+            return (invitations.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Invitations.
+        /// </summary>
+        /// <remarks>
+        /// Invite one or more users to your company.
+        /// </remarks>
+        /// <param name="invitations">
+        /// The set of <see cref="Invitation"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Invitation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
+            IEnumerable<Invitation> invitations)
+        {
+            return await CreateInvitationsAsync(invitations, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Invitations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Invite one or more users to your company.
+        /// </remarks>
+        /// <param name="invitations">
+        /// The set of <see cref="Invitation"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Invitation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
+            IEnumerable<Invitation> invitations,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<Invitation>(EndpointName.Invitations, invitations);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Invitations.cs
+++ b/Intuit.TSheets/Api/DataService_Invitations.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -88,13 +89,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Invitation"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(IEnumerable<Invitation> invitations)
+        public async Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
+            IEnumerable<Invitation> invitations)
         {
             var context = new CreateContext<Invitation>(EndpointName.Invitations, invitations);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Invitations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Invite one or more users to your company.
+        /// </remarks>
+        /// <param name="invitations">
+        /// The set of <see cref="Invitation"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Invitation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
+            IEnumerable<Invitation> invitations,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -110,11 +137,37 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Invitation"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Invitation, ResultsMeta)> CreateInvitationAsync(Invitation invitation)
+        public async Task<(Invitation, ResultsMeta)> CreateInvitationAsync(
+            Invitation invitation)
         {
             (IList<Invitation> invitations, ResultsMeta resultsMeta) = await CreateInvitationsAsync(new[] { invitation }).ConfigureAwait(false);
 
             return (invitations.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Invitations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Invite a single user to your company.
+        /// </remarks>
+        /// <param name="invitation">
+        /// The <see cref="Invitation"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Invitation"/> object that was created, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Invitation, ResultsMeta)> CreateInvitationAsync(
+            Invitation invitation,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_JobcodeAssignments.cs
+++ b/Intuit.TSheets/Api/DataService_JobcodeAssignments.cs
@@ -129,6 +129,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all jobcode assignments associated with users,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<JobcodeAssignment>, ResultsMeta) GetJobcodeAssignments()
+        {
+            return AsyncUtil.RunSync(() => GetJobcodeAssignmentsAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -136,9 +152,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public (IList<JobcodeAssignment>, ResultsMeta) GetJobcodeAssignments(RequestOptions options = null)
+        public (IList<JobcodeAssignment>, ResultsMeta) GetJobcodeAssignments(
+            RequestOptions options)
         {
-            return GetJobcodeAssignments(null, options);
+            return AsyncUtil.RunSync(() => GetJobcodeAssignmentsAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeAssignmentFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<JobcodeAssignment>, ResultsMeta) GetJobcodeAssignments(
+            JobcodeAssignmentFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetJobcodeAssignmentsAsync(filter));
         }
 
         /// <summary>
@@ -160,9 +197,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<JobcodeAssignment>, ResultsMeta) GetJobcodeAssignments(
             JobcodeAssignmentFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetJobcodeAssignmentsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync()
+        {
+            return await GetJobcodeAssignmentsAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -179,9 +232,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(RequestOptions options = null)
+        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            RequestOptions options)
         {
             return await GetJobcodeAssignmentsAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeAssignmentFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            JobcodeAssignmentFilter filter)
+        {
+            return await GetJobcodeAssignmentsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -203,7 +277,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
             JobcodeAssignmentFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<JobcodeAssignment>(EndpointName.JobcodeAssignments, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_JobcodeAssignments.cs
+++ b/Intuit.TSheets/Api/DataService_JobcodeAssignments.cs
@@ -43,24 +43,6 @@ namespace Intuit.TSheets.Api
         /// Create Jobcode Assignments.
         /// </summary>
         /// <remarks>
-        /// Add one or more jobcode assignments to a user.
-        /// </remarks>
-        /// <param name="jobcodeAssignments">
-        /// The set of <see cref="JobcodeAssignment"/> assignments to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<JobcodeAssignment>, ResultsMeta) CreateJobcodeAssignments(IEnumerable<JobcodeAssignment> jobcodeAssignments)
-        {
-            return AsyncUtil.RunSync(() => CreateJobcodeAssignmentsAsync(jobcodeAssignments));
-        }
-
-        /// <summary>
-        /// Create Jobcode Assignments.
-        /// </summary>
-        /// <remarks>
         /// Add a single jobcode assignment to a user.
         /// </remarks>
         /// <param name="jobcodeAssignment">
@@ -78,7 +60,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Jobcode Assignments.
+        /// Create Jobcode Assignments.
         /// </summary>
         /// <remarks>
         /// Add one or more jobcode assignments to a user.
@@ -90,39 +72,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
-            IEnumerable<JobcodeAssignment> jobcodeAssignments)
+        public (IList<JobcodeAssignment>, ResultsMeta) CreateJobcodeAssignments(IEnumerable<JobcodeAssignment> jobcodeAssignments)
         {
-            var context = new CreateContext<JobcodeAssignment>(EndpointName.JobcodeAssignments, jobcodeAssignments);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Jobcode Assignments, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more jobcode assignments to a user.
-        /// </remarks>
-        /// <param name="jobcodeAssignments">
-        /// The set of <see cref="JobcodeAssignment"/> assignments to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
-            IEnumerable<JobcodeAssignment> jobcodeAssignments,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateJobcodeAssignmentsAsync(jobcodeAssignments));
         }
 
         /// <summary>
@@ -141,7 +93,7 @@ namespace Intuit.TSheets.Api
         public async Task<(JobcodeAssignment, ResultsMeta)> CreateJobcodeAssignmentAsync(
             JobcodeAssignment jobcodeAssignment)
         {
-            (IList<JobcodeAssignment> jobcodeAssignments, ResultsMeta resultsMeta) = await CreateJobcodeAssignmentsAsync(new[] { jobcodeAssignment }).ConfigureAwait(false);
+            (IList<JobcodeAssignment> jobcodeAssignments, ResultsMeta resultsMeta) = await CreateJobcodeAssignmentsAsync(new[] { jobcodeAssignment }, default).ConfigureAwait(false);
 
             return (jobcodeAssignments.FirstOrDefault(), resultsMeta);
         }
@@ -166,9 +118,55 @@ namespace Intuit.TSheets.Api
             JobcodeAssignment jobcodeAssignment,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<JobcodeAssignment> jobcodeAssignments, ResultsMeta resultsMeta) = await CreateJobcodeAssignmentsAsync(new[] { jobcodeAssignment }, cancellationToken).ConfigureAwait(false);
+
+            return (jobcodeAssignments.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcode assignments to a user.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignments to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments)
+        {
+            return await CreateJobcodeAssignmentsAsync(jobcodeAssignments, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcode assignments to a user.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignments to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<JobcodeAssignment>(EndpointName.JobcodeAssignments, jobcodeAssignments);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -268,7 +266,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync()
         {
-            return await GetJobcodeAssignmentsAsync(null, null).ConfigureAwait(false);
+            return await GetJobcodeAssignmentsAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -288,9 +286,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetJobcodeAssignmentsAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -310,7 +306,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
             RequestOptions options)
         {
-            return await GetJobcodeAssignmentsAsync(null, options).ConfigureAwait(false);
+            return await GetJobcodeAssignmentsAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -334,9 +330,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetJobcodeAssignmentsAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -356,7 +350,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
             JobcodeAssignmentFilter filter)
         {
-            return await GetJobcodeAssignmentsAsync(filter, null).ConfigureAwait(false);
+            return await GetJobcodeAssignmentsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -380,9 +374,7 @@ namespace Intuit.TSheets.Api
             JobcodeAssignmentFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetJobcodeAssignmentsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -406,11 +398,7 @@ namespace Intuit.TSheets.Api
             JobcodeAssignmentFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<JobcodeAssignment>(EndpointName.JobcodeAssignments, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetJobcodeAssignmentsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -438,9 +426,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<JobcodeAssignment>(EndpointName.JobcodeAssignments, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -458,7 +448,21 @@ namespace Intuit.TSheets.Api
         /// </param>
         public void DeleteJobcodeAssignment(JobcodeAssignment jobcodeAssignment)
         {
-            DeleteJobcodeAssignments(new[] { jobcodeAssignment });
+            AsyncUtil.RunSync(() => DeleteJobcodeAssignmentAsync(jobcodeAssignment));
+        }
+
+        /// <summary>
+        /// Delete Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="JobcodeAssignment"/> assignment, by id.
+        /// </remarks>
+        /// <param name="id">
+        /// The id of the <see cref="JobcodeAssignment"/> assignment object to be deleted.
+        /// </param>
+        public void DeleteJobcodeAssignment(int id)
+        {
+            AsyncUtil.RunSync(() => DeleteJobcodeAssignmentAsync(id));
         }
 
         /// <summary>
@@ -473,25 +477,9 @@ namespace Intuit.TSheets.Api
         public void DeleteJobcodeAssignments(
             IEnumerable<JobcodeAssignment> jobcodeAssignments)
         {
-            IEnumerable<int> ids = jobcodeAssignments.Select(j => j.Id);
-
-            DeleteJobcodeAssignments(ids);
+            AsyncUtil.RunSync(() => DeleteJobcodeAssignmentsAsync(jobcodeAssignments));
         }
-
-        /// <summary>
-        /// Delete Jobcode Assignments.
-        /// </summary>
-        /// <remarks>
-        /// Delete a single <see cref="JobcodeAssignment"/> assignment, by id.
-        /// </remarks>
-        /// <param name="id">
-        /// The id of the <see cref="JobcodeAssignment"/> assignment object to be deleted.
-        /// </param>
-        public void DeleteJobcodeAssignment(int id)
-        {
-            DeleteJobcodeAssignments(new[] { id });
-        }
-
+     
         /// <summary>
         /// Delete Jobcode Assignments.
         /// </summary>
@@ -519,7 +507,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteJobcodeAssignmentAsync(
             JobcodeAssignment jobcodeAssignment)
         {
-            await DeleteJobcodeAssignmentsAsync(new[] { jobcodeAssignment }).ConfigureAwait(false);
+            await DeleteJobcodeAssignmentsAsync(new[] { jobcodeAssignment }, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -539,49 +527,7 @@ namespace Intuit.TSheets.Api
             JobcodeAssignment jobcodeAssignment,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
-        }
-
-        /// <summary>
-        /// Asynchronously Delete Jobcode Assignments.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
-        /// </remarks>
-        /// <param name="jobcodeAssignments">
-        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        public async Task DeleteJobcodeAssignmentsAsync(
-            IEnumerable<JobcodeAssignment> jobcodeAssignments)
-        {
-            IEnumerable<int> ids = jobcodeAssignments.Select(t => t.Id);
-
-            await DeleteJobcodeAssignmentsAsync(ids).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
-        /// </remarks>
-        /// <param name="jobcodeAssignments">
-        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        public async Task DeleteJobcodeAssignmentsAsync(
-            IEnumerable<JobcodeAssignment> jobcodeAssignments,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            await DeleteJobcodeAssignmentsAsync(new[] { jobcodeAssignment }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -597,7 +543,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteJobcodeAssignmentAsync(
             int id)
         {
-            await DeleteJobcodeAssignmentsAsync(new[] { id }).ConfigureAwait(false);
+            await DeleteJobcodeAssignmentsAsync(new[] { id }, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -617,9 +563,47 @@ namespace Intuit.TSheets.Api
             int id,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            await DeleteJobcodeAssignmentsAsync(new[] { id }, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments)
+        {
+            IEnumerable<int> ids = jobcodeAssignments.Select(t => t.Id);
+
+            await DeleteJobcodeAssignmentsAsync(ids, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments,
+            CancellationToken cancellationToken)
+        {
+            IEnumerable<int> ids = jobcodeAssignments.Select(t => t.Id);
+
+            await DeleteJobcodeAssignmentsAsync(ids, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -635,9 +619,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteJobcodeAssignmentsAsync(
             IEnumerable<int> ids)
         {
-            var context = new DeleteContext<JobcodeAssignment>(EndpointName.JobcodeAssignments, ids);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
+            await DeleteJobcodeAssignmentsAsync(ids, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -657,9 +639,9 @@ namespace Intuit.TSheets.Api
             IEnumerable<int> ids,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new DeleteContext<JobcodeAssignment>(EndpointName.JobcodeAssignments, ids);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_JobcodeAssignments.cs
+++ b/Intuit.TSheets/Api/DataService_JobcodeAssignments.cs
@@ -507,7 +507,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteJobcodeAssignmentAsync(
             JobcodeAssignment jobcodeAssignment)
         {
-            await DeleteJobcodeAssignmentsAsync(new[] { jobcodeAssignment }, default).ConfigureAwait(false);
+            await DeleteJobcodeAssignmentsAsync(new[] { jobcodeAssignment.Id }, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -527,7 +527,7 @@ namespace Intuit.TSheets.Api
             JobcodeAssignment jobcodeAssignment,
             CancellationToken cancellationToken)
         {
-            await DeleteJobcodeAssignmentsAsync(new[] { jobcodeAssignment }, cancellationToken).ConfigureAwait(false);
+            await DeleteJobcodeAssignmentsAsync(new[] { jobcodeAssignment.Id }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Intuit.TSheets/Api/DataService_JobcodeAssignments.cs
+++ b/Intuit.TSheets/Api/DataService_JobcodeAssignments.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -89,13 +90,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(IEnumerable<JobcodeAssignment> jobcodeAssignments)
+        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments)
         {
             var context = new CreateContext<JobcodeAssignment>(EndpointName.JobcodeAssignments, jobcodeAssignments);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcode assignments to a user.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignments to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -111,11 +138,37 @@ namespace Intuit.TSheets.Api
         /// The <see cref="JobcodeAssignment"/> assignment that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(JobcodeAssignment, ResultsMeta)> CreateJobcodeAssignmentAsync(JobcodeAssignment jobcodeAssignment)
+        public async Task<(JobcodeAssignment, ResultsMeta)> CreateJobcodeAssignmentAsync(
+            JobcodeAssignment jobcodeAssignment)
         {
             (IList<JobcodeAssignment> jobcodeAssignments, ResultsMeta resultsMeta) = await CreateJobcodeAssignmentsAsync(new[] { jobcodeAssignment }).ConfigureAwait(false);
 
             return (jobcodeAssignments.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single jobcode assignment to a user.
+        /// </remarks>
+        /// <param name="jobcodeAssignment">
+        /// The <see cref="JobcodeAssignment"/> assignment to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="JobcodeAssignment"/> assignment that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(JobcodeAssignment, ResultsMeta)> CreateJobcodeAssignmentAsync(
+            JobcodeAssignment jobcodeAssignment,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -219,6 +272,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Jobcode Assignments.
         /// </summary>
         /// <remarks>
@@ -239,6 +314,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Jobcode Assignments.
         /// </summary>
         /// <remarks>
@@ -256,6 +357,32 @@ namespace Intuit.TSheets.Api
             JobcodeAssignmentFilter filter)
         {
             return await GetJobcodeAssignmentsAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeAssignmentFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            JobcodeAssignmentFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -284,6 +411,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeAssignmentFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            JobcodeAssignmentFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -359,9 +516,32 @@ namespace Intuit.TSheets.Api
         /// The <see cref="JobcodeAssignment"/> assignment object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteJobcodeAssignmentAsync(JobcodeAssignment jobcodeAssignment)
+        public async Task DeleteJobcodeAssignmentAsync(
+            JobcodeAssignment jobcodeAssignment)
         {
             await DeleteJobcodeAssignmentsAsync(new[] { jobcodeAssignment }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="JobcodeAssignment"/> assignment.
+        /// </remarks>
+        /// <param name="jobcodeAssignment">
+        /// The <see cref="JobcodeAssignment"/> assignment object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteJobcodeAssignmentAsync(
+            JobcodeAssignment jobcodeAssignment,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -374,11 +554,34 @@ namespace Intuit.TSheets.Api
         /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteJobcodeAssignmentsAsync(IEnumerable<JobcodeAssignment> jobcodeAssignments)
+        public async Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments)
         {
             IEnumerable<int> ids = jobcodeAssignments.Select(t => t.Id);
 
             await DeleteJobcodeAssignmentsAsync(ids).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -391,9 +594,32 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="JobcodeAssignment"/> assignment object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteJobcodeAssignmentAsync(int id)
+        public async Task DeleteJobcodeAssignmentAsync(
+            int id)
         {
             await DeleteJobcodeAssignmentsAsync(new[] { id }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="JobcodeAssignment"/> assignment, by id.
+        /// </remarks>
+        /// <param name="id">
+        /// The id of the <see cref="JobcodeAssignment"/> assignment object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteJobcodeAssignmentAsync(
+            int id,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -406,11 +632,34 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="JobcodeAssignment"/> assignment objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteJobcodeAssignmentsAsync(IEnumerable<int> ids)
+        public async Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<int> ids)
         {
             var context = new DeleteContext<JobcodeAssignment>(EndpointName.JobcodeAssignments, ids);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="JobcodeAssignment"/> assignments, by id.
+        /// </remarks>
+        /// <param name="ids">
+        /// The set of ids for the <see cref="JobcodeAssignment"/> assignment objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<int> ids,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Jobcodes.cs
+++ b/Intuit.TSheets/Api/DataService_Jobcodes.cs
@@ -43,24 +43,6 @@ namespace Intuit.TSheets.Api
         /// Create Jobcodes.
         /// </summary>
         /// <remarks>
-        /// Add one or more jobcodes to your company.
-        /// </remarks>
-        /// <param name="jobcodes">
-        /// The set of <see cref="Jobcode"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Jobcode"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Jobcode>, ResultsMeta) CreateJobcodes(IEnumerable<Jobcode> jobcodes)
-        {
-            return AsyncUtil.RunSync(() => CreateJobcodesAsync(jobcodes));
-        }
-
-        /// <summary>
-        /// Create Jobcodes.
-        /// </summary>
-        /// <remarks>
         /// Add a single jobcode to your company.
         /// </remarks>
         /// <param name="jobcode">
@@ -78,7 +60,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Jobcodes.
+        /// Create Jobcodes.
         /// </summary>
         /// <remarks>
         /// Add one or more jobcodes to your company.
@@ -90,39 +72,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Jobcode"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
-            IEnumerable<Jobcode> jobcodes)
+        public (IList<Jobcode>, ResultsMeta) CreateJobcodes(IEnumerable<Jobcode> jobcodes)
         {
-            var context = new CreateContext<Jobcode>(EndpointName.Jobcodes, jobcodes);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Jobcodes, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more jobcodes to your company.
-        /// </remarks>
-        /// <param name="jobcodes">
-        /// The set of <see cref="Jobcode"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Jobcode"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
-            IEnumerable<Jobcode> jobcodes,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateJobcodesAsync(jobcodes));
         }
 
         /// <summary>
@@ -141,7 +93,7 @@ namespace Intuit.TSheets.Api
         public async Task<(Jobcode, ResultsMeta)> CreateJobcodeAsync(
             Jobcode jobcode)
         {
-            (IList<Jobcode> jobcodes, ResultsMeta resultsMeta) = await CreateJobcodesAsync(new[] { jobcode }).ConfigureAwait(false);
+            (IList<Jobcode> jobcodes, ResultsMeta resultsMeta) = await CreateJobcodesAsync(new[] { jobcode }, default).ConfigureAwait(false);
 
             return (jobcodes.FirstOrDefault(), resultsMeta);
         }
@@ -166,9 +118,55 @@ namespace Intuit.TSheets.Api
             Jobcode jobcode,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Jobcode> jobcodes, ResultsMeta resultsMeta) = await CreateJobcodesAsync(new[] { jobcode }, cancellationToken).ConfigureAwait(false);
+
+            return (jobcodes.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcodes to your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Jobcode"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes)
+        {
+            return await CreateJobcodesAsync(jobcodes, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcodes to your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Jobcode"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<Jobcode>(EndpointName.Jobcodes, jobcodes);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -268,7 +266,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync()
         {
-            return await GetJobcodesAsync(null, null).ConfigureAwait(false);
+            return await GetJobcodesAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -288,9 +286,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetJobcodesAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -310,7 +306,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
             RequestOptions options)
         {
-            return await GetJobcodesAsync(null, options).ConfigureAwait(false);
+            return await GetJobcodesAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -334,9 +330,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetJobcodesAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -356,7 +350,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
             JobcodeFilter filter)
         {
-            return await GetJobcodesAsync(filter, null).ConfigureAwait(false);
+            return await GetJobcodesAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -380,9 +374,7 @@ namespace Intuit.TSheets.Api
             JobcodeFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetJobcodesAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -406,11 +398,7 @@ namespace Intuit.TSheets.Api
             JobcodeFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<Jobcode>(EndpointName.Jobcodes, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetJobcodesAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -438,33 +426,16 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<Jobcode>(EndpointName.Jobcodes, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
 
         #region Update methods
-
-        /// <summary>
-        /// Update Jobcodes.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more jobcodes in your company.
-        /// </remarks>
-        /// <param name="jobcodes">
-        /// The set of <see cref="Jobcode"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Jobcode"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Jobcode>, ResultsMeta) UpdateJobcodes(
-            IEnumerable<Jobcode> jobcodes)
-        {
-            return AsyncUtil.RunSync(() => UpdateJobcodesAsync(jobcodes));
-        }
 
         /// <summary>
         /// Update Jobcodes.
@@ -488,7 +459,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Update Jobcodes.
+        /// Update Jobcodes.
         /// </summary>
         /// <remarks>
         /// Edit one or more jobcodes in your company.
@@ -500,39 +471,10 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Jobcode"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
+        public (IList<Jobcode>, ResultsMeta) UpdateJobcodes(
             IEnumerable<Jobcode> jobcodes)
         {
-            var context = new UpdateContext<Jobcode>(EndpointName.Jobcodes, jobcodes);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Update Jobcodes, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more jobcodes in your company.
-        /// </remarks>
-        /// <param name="jobcodes">
-        /// The set of <see cref="Jobcode"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// The set of the <see cref="Jobcode"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
-            IEnumerable<Jobcode> jobcodes,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => UpdateJobcodesAsync(jobcodes));
         }
 
         /// <summary>
@@ -552,7 +494,7 @@ namespace Intuit.TSheets.Api
             Jobcode jobcode)
         {
             (IList<Jobcode> jobcodes, ResultsMeta resultsMeta) =
-                await UpdateJobcodesAsync(new[] { jobcode }).ConfigureAwait(false);
+                await UpdateJobcodesAsync(new[] { jobcode }, default).ConfigureAwait(false);
 
             return (jobcodes.FirstOrDefault(), resultsMeta);
         }
@@ -577,9 +519,56 @@ namespace Intuit.TSheets.Api
             Jobcode jobcode,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Jobcode> jobcodes, ResultsMeta resultsMeta) =
+                await UpdateJobcodesAsync(new[] { jobcode }, cancellationToken).ConfigureAwait(false);
+
+            return (jobcodes.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more jobcodes in your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Jobcode"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes)
+        {
+            return await UpdateJobcodesAsync(jobcodes, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more jobcodes in your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// The set of the <see cref="Jobcode"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes,
+            CancellationToken cancellationToken)
+        {
+            var context = new UpdateContext<Jobcode>(EndpointName.Jobcodes, jobcodes);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Jobcodes.cs
+++ b/Intuit.TSheets/Api/DataService_Jobcodes.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -89,13 +90,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Jobcode"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(IEnumerable<Jobcode> jobcodes)
+        public async Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes)
         {
             var context = new CreateContext<Jobcode>(EndpointName.Jobcodes, jobcodes);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcodes to your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Jobcode"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -111,11 +138,37 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Jobcode"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Jobcode, ResultsMeta)> CreateJobcodeAsync(Jobcode jobcode)
+        public async Task<(Jobcode, ResultsMeta)> CreateJobcodeAsync(
+            Jobcode jobcode)
         {
             (IList<Jobcode> jobcodes, ResultsMeta resultsMeta) = await CreateJobcodesAsync(new[] { jobcode }).ConfigureAwait(false);
 
             return (jobcodes.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single jobcode to your company.
+        /// </remarks>
+        /// <param name="jobcode">
+        /// The <see cref="Jobcode"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Jobcode"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Jobcode, ResultsMeta)> CreateJobcodeAsync(
+            Jobcode jobcode,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -219,6 +272,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Jobcodes.
         /// </summary>
         /// <remarks>
@@ -239,6 +314,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Jobcodes.
         /// </summary>
         /// <remarks>
@@ -256,6 +357,32 @@ namespace Intuit.TSheets.Api
             JobcodeFilter filter)
         {
             return await GetJobcodesAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            JobcodeFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -284,6 +411,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            JobcodeFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -343,13 +500,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Jobcode"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(IEnumerable<Jobcode> jobcodes)
+        public async Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes)
         {
             var context = new UpdateContext<Jobcode>(EndpointName.Jobcodes, jobcodes);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more jobcodes in your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// The set of the <see cref="Jobcode"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -365,12 +548,38 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Jobcode"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Jobcode, ResultsMeta)> UpdateJobcodeAsync(Jobcode jobcode)
+        public async Task<(Jobcode, ResultsMeta)> UpdateJobcodeAsync(
+            Jobcode jobcode)
         {
             (IList<Jobcode> jobcodes, ResultsMeta resultsMeta) =
                 await UpdateJobcodesAsync(new[] { jobcode }).ConfigureAwait(false);
 
             return (jobcodes.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single jobcode in your company.
+        /// </remarks>
+        /// <param name="jobcode">
+        /// The <see cref="Jobcode"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Jobcode"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Jobcode, ResultsMeta)> UpdateJobcodeAsync(
+            Jobcode jobcode,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Jobcodes.cs
+++ b/Intuit.TSheets/Api/DataService_Jobcodes.cs
@@ -129,6 +129,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all jobcodes associated with your company,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<Jobcode>, ResultsMeta) GetJobcodes()
+        {
+            return AsyncUtil.RunSync(() => GetJobcodesAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -136,9 +152,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public (IList<Jobcode>, ResultsMeta) GetJobcodes(RequestOptions options = null)
+        public (IList<Jobcode>, ResultsMeta) GetJobcodes(
+            RequestOptions options)
         {
-            return GetJobcodes(null, options);
+            return AsyncUtil.RunSync(() => GetJobcodesAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<Jobcode>, ResultsMeta) GetJobcodes(
+            JobcodeFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetJobcodesAsync(filter));
         }
 
         /// <summary>
@@ -160,9 +197,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<Jobcode>, ResultsMeta) GetJobcodes(
             JobcodeFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetJobcodesAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync()
+        {
+            return await GetJobcodesAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -179,9 +232,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(RequestOptions options = null)
+        public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            RequestOptions options)
         {
             return await GetJobcodesAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            JobcodeFilter filter)
+        {
+            return await GetJobcodesAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -203,7 +277,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
             JobcodeFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<Jobcode>(EndpointName.Jobcodes, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_LastModifiedTimestamps.cs
+++ b/Intuit.TSheets/Api/DataService_LastModifiedTimestamps.cs
@@ -80,7 +80,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public async Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync()
         {
-            return await GetLastModifiedTimestampsAsync(null).ConfigureAwait(false);
+            return await GetLastModifiedTimestampsAsync(null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -98,9 +98,7 @@ namespace Intuit.TSheets.Api
         public async Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetLastModifiedTimestampsAsync(null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -118,11 +116,7 @@ namespace Intuit.TSheets.Api
         public async Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync(
             LastModifiedTimestampsFilter filter)
         {
-            var context = new GetContext<LastModifiedTimestamps>(EndpointName.LastModifiedTimestamps, filter);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return context.Results.Items.FirstOrDefault();
+            return await GetLastModifiedTimestampsAsync(filter, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -144,9 +138,11 @@ namespace Intuit.TSheets.Api
             LastModifiedTimestampsFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<LastModifiedTimestamps>(EndpointName.LastModifiedTimestamps, filter);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return context.Results.Items.FirstOrDefault();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_LastModifiedTimestamps.cs
+++ b/Intuit.TSheets/Api/DataService_LastModifiedTimestamps.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -83,6 +84,26 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Last Modified Timestamps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of last modified timestamps associated with each requested API endpoint. 
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of a <see cref="LastModifiedTimestamps"/> class.
+        /// </returns>
+        public async Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Last Modified Timestamps.
         /// </summary>
         /// <remarks>
@@ -94,13 +115,38 @@ namespace Intuit.TSheets.Api
         /// <returns>
         /// An instance of a <see cref="LastModifiedTimestamps"/> class.
         /// </returns>
-        public async Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync(LastModifiedTimestampsFilter filter)
+        public async Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync(
+            LastModifiedTimestampsFilter filter)
         {
             var context = new GetContext<LastModifiedTimestamps>(EndpointName.LastModifiedTimestamps, filter);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return context.Results.Items.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Last Modified Timestamps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of last modified timestamps associated with each requested API endpoint. 
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LastModifiedTimestampsFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of a <see cref="LastModifiedTimestamps"/> class.
+        /// </returns>
+        public async Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync(
+            LastModifiedTimestampsFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Locations.cs
+++ b/Intuit.TSheets/Api/DataService_Locations.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -89,13 +90,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Location"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(IEnumerable<Location> locations)
+        public async Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
+            IEnumerable<Location> locations)
         {
             var context = new CreateContext<Location>(EndpointName.Locations, locations);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more locations to your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
+            IEnumerable<Location> locations,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -111,11 +138,37 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Location"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Location, ResultsMeta)> CreateLocationAsync(Location location)
+        public async Task<(Location, ResultsMeta)> CreateLocationAsync(
+            Location location)
         {
             (IList<Location> locations, ResultsMeta resultsMeta) = await CreateLocationsAsync(new[] { location }).ConfigureAwait(false);
 
             return (locations.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single location to your company.
+        /// </remarks>
+        /// <param name="location">
+        /// The <see cref="Location"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Location"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Location, ResultsMeta)> CreateLocationAsync(
+            Location location,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -219,6 +272,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Locations.
         /// </summary>
         /// <remarks>
@@ -239,6 +314,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Locations.
         /// </summary>
         /// <remarks>
@@ -256,6 +357,32 @@ namespace Intuit.TSheets.Api
             LocationFilter filter)
         {
             return await GetLocationsAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            LocationFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -284,6 +411,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            LocationFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -342,13 +499,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Location"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(IEnumerable<Location> locations)
+        public async Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
+            IEnumerable<Location> locations)
         {
             var context = new UpdateContext<Location>(EndpointName.Locations, locations);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more locations in your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
+            IEnumerable<Location> locations,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -364,12 +547,38 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Location"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Location, ResultsMeta)> UpdateLocationAsync(Location location)
+        public async Task<(Location, ResultsMeta)> UpdateLocationAsync(
+            Location location)
         {
             (IList<Location> locations, ResultsMeta resultsMeta) =
                 await UpdateLocationsAsync(new[] { location }).ConfigureAwait(false);
 
             return (locations.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single location in your company.
+        /// </remarks>
+        /// <param name="location">
+        /// The <see cref="Location"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Location"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Location, ResultsMeta)> UpdateLocationAsync(
+            Location location,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Locations.cs
+++ b/Intuit.TSheets/Api/DataService_Locations.cs
@@ -43,24 +43,6 @@ namespace Intuit.TSheets.Api
         /// Create Locations.
         /// </summary>
         /// <remarks>
-        /// Add one or more locations to your company.
-        /// </remarks>
-        /// <param name="locations">
-        /// The set of <see cref="Location"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Location"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Location>, ResultsMeta) CreateLocations(IEnumerable<Location> locations)
-        {
-            return AsyncUtil.RunSync(() => CreateLocationsAsync(locations));
-        }
-
-        /// <summary>
-        /// Create Locations.
-        /// </summary>
-        /// <remarks>
         /// Add a single location to your company.
         /// </remarks>
         /// <param name="location">
@@ -78,7 +60,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Locations.
+        /// Create Locations.
         /// </summary>
         /// <remarks>
         /// Add one or more locations to your company.
@@ -90,39 +72,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Location"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
-            IEnumerable<Location> locations)
+        public (IList<Location>, ResultsMeta) CreateLocations(IEnumerable<Location> locations)
         {
-            var context = new CreateContext<Location>(EndpointName.Locations, locations);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Locations, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more locations to your company.
-        /// </remarks>
-        /// <param name="locations">
-        /// The set of <see cref="Location"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Location"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
-            IEnumerable<Location> locations,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateLocationsAsync(locations));
         }
 
         /// <summary>
@@ -141,7 +93,7 @@ namespace Intuit.TSheets.Api
         public async Task<(Location, ResultsMeta)> CreateLocationAsync(
             Location location)
         {
-            (IList<Location> locations, ResultsMeta resultsMeta) = await CreateLocationsAsync(new[] { location }).ConfigureAwait(false);
+            (IList<Location> locations, ResultsMeta resultsMeta) = await CreateLocationsAsync(new[] { location }, default).ConfigureAwait(false);
 
             return (locations.FirstOrDefault(), resultsMeta);
         }
@@ -166,9 +118,55 @@ namespace Intuit.TSheets.Api
             Location location,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Location> locations, ResultsMeta resultsMeta) = await CreateLocationsAsync(new[] { location }, cancellationToken).ConfigureAwait(false);
+
+            return (locations.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Locations.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more locations to your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
+            IEnumerable<Location> locations)
+        {
+            return await CreateLocationsAsync(locations, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more locations to your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
+            IEnumerable<Location> locations,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<Location>(EndpointName.Locations, locations);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -268,7 +266,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync()
         {
-            return await GetLocationsAsync(null, null).ConfigureAwait(false);
+            return await GetLocationsAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -288,9 +286,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetLocationsAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -310,7 +306,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
             RequestOptions options)
         {
-            return await GetLocationsAsync(null, options).ConfigureAwait(false);
+            return await GetLocationsAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -334,9 +330,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetLocationsAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -356,7 +350,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
             LocationFilter filter)
         {
-            return await GetLocationsAsync(filter, null).ConfigureAwait(false);
+            return await GetLocationsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -380,9 +374,7 @@ namespace Intuit.TSheets.Api
             LocationFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetLocationsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -406,11 +398,7 @@ namespace Intuit.TSheets.Api
             LocationFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<Location>(EndpointName.Locations, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetLocationsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -438,32 +426,16 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<Location>(EndpointName.Locations, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
 
         #region Update methods
-
-        /// <summary>
-        /// Update Locations.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more locations in your company.
-        /// </remarks>
-        /// <param name="locations">
-        /// The set of <see cref="Location"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Location"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Location>, ResultsMeta) UpdateLocations(IEnumerable<Location> locations)
-        {
-            return AsyncUtil.RunSync(() => UpdateLocationsAsync(locations));
-        }
 
         /// <summary>
         /// Update Locations.
@@ -487,7 +459,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Update Locations.
+        /// Update Locations.
         /// </summary>
         /// <remarks>
         /// Edit one or more locations in your company.
@@ -499,39 +471,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Location"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
-            IEnumerable<Location> locations)
+        public (IList<Location>, ResultsMeta) UpdateLocations(IEnumerable<Location> locations)
         {
-            var context = new UpdateContext<Location>(EndpointName.Locations, locations);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Update Locations, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more locations in your company.
-        /// </remarks>
-        /// <param name="locations">
-        /// The set of <see cref="Location"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Location"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
-            IEnumerable<Location> locations,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => UpdateLocationsAsync(locations));
         }
 
         /// <summary>
@@ -551,7 +493,7 @@ namespace Intuit.TSheets.Api
             Location location)
         {
             (IList<Location> locations, ResultsMeta resultsMeta) =
-                await UpdateLocationsAsync(new[] { location }).ConfigureAwait(false);
+                await UpdateLocationsAsync(new[] { location }, default).ConfigureAwait(false);
 
             return (locations.FirstOrDefault(), resultsMeta);
         }
@@ -576,9 +518,56 @@ namespace Intuit.TSheets.Api
             Location location,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Location> locations, ResultsMeta resultsMeta) =
+               await UpdateLocationsAsync(new[] { location }, cancellationToken).ConfigureAwait(false);
+
+            return (locations.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Locations.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more locations in your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
+            IEnumerable<Location> locations)
+        {
+            return await UpdateLocationsAsync(locations, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more locations in your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
+            IEnumerable<Location> locations,
+            CancellationToken cancellationToken)
+        {
+            var context = new UpdateContext<Location>(EndpointName.Locations, locations);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Locations.cs
+++ b/Intuit.TSheets/Api/DataService_Locations.cs
@@ -129,6 +129,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all locations associated with your company,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<Location>, ResultsMeta) GetLocations()
+        {
+            return AsyncUtil.RunSync(() => GetLocationsAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Locations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -136,9 +152,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Location"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public (IList<Location>, ResultsMeta) GetLocations(RequestOptions options = null)
+        public (IList<Location>, ResultsMeta) GetLocations(
+            RequestOptions options)
         {
-            return GetLocations(null, options);
+            return AsyncUtil.RunSync(() => GetLocationsAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Locations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<Location>, ResultsMeta) GetLocations(
+            LocationFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetLocationsAsync(filter));
         }
 
         /// <summary>
@@ -160,9 +197,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<Location>, ResultsMeta) GetLocations(
             LocationFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetLocationsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Locations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync()
+        {
+            return await GetLocationsAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -179,9 +232,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Location"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(RequestOptions options = null)
+        public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            RequestOptions options)
         {
             return await GetLocationsAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Locations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            LocationFilter filter)
+        {
+            return await GetLocationsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -203,7 +277,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
             LocationFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<Location>(EndpointName.Locations, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_LocationsMaps.cs
+++ b/Intuit.TSheets/Api/DataService_LocationsMaps.cs
@@ -44,6 +44,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all locations maps associated with your company,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="LocationsMap"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<LocationsMap>, ResultsMeta) GetLocationsMaps()
+        {
+            return AsyncUtil.RunSync(() => GetLocationsMapsAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Locations Maps.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations maps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -51,9 +67,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="LocationsMap"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public (IList<LocationsMap>, ResultsMeta) GetLocationsMaps(RequestOptions options = null)
+        public (IList<LocationsMap>, ResultsMeta) GetLocationsMaps(
+            RequestOptions options)
         {
-            return GetLocationsMaps(null, options);
+            return AsyncUtil.RunSync(() => GetLocationsMapsAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Locations Maps.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations maps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationsMapFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="LocationsMap"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<LocationsMap>, ResultsMeta) GetLocationsMaps(
+            LocationsMapFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetLocationsMapsAsync(filter));
         }
 
         /// <summary>
@@ -75,9 +112,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<LocationsMap>, ResultsMeta) GetLocationsMaps(
             LocationsMapFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetLocationsMapsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve LocationsMaps.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync()
+        {
+            return await GetLocationsMapsAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -94,9 +147,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Location"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(RequestOptions options = null)
+        public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            RequestOptions options)
         {
             return await GetLocationsMapsAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve LocationsMaps.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            LocationsMapFilter filter)
+        {
+            return await GetLocationsMapsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -118,7 +192,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
             LocationsMapFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<LocationsMap>(EndpointName.LocationsMaps, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_LocationsMaps.cs
+++ b/Intuit.TSheets/Api/DataService_LocationsMaps.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -134,6 +135,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve LocationsMaps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve LocationsMaps.
         /// </summary>
         /// <remarks>
@@ -154,6 +177,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve LocationsMaps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve LocationsMaps.
         /// </summary>
         /// <remarks>
@@ -171,6 +220,32 @@ namespace Intuit.TSheets.Api
             LocationsMapFilter filter)
         {
             return await GetLocationsMapsAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve LocationsMaps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            LocationsMapFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -199,6 +274,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve LocationsMaps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            LocationsMapFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_LocationsMaps.cs
+++ b/Intuit.TSheets/Api/DataService_LocationsMaps.cs
@@ -131,7 +131,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync()
         {
-            return await GetLocationsMapsAsync(null, null).ConfigureAwait(false);
+            return await GetLocationsMapsAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -151,9 +151,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetLocationsMapsAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -173,7 +171,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
             RequestOptions options)
         {
-            return await GetLocationsMapsAsync(null, options).ConfigureAwait(false);
+            return await GetLocationsMapsAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -197,9 +195,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetLocationsMapsAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,7 +215,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
             LocationsMapFilter filter)
         {
-            return await GetLocationsMapsAsync(filter, null).ConfigureAwait(false);
+            return await GetLocationsMapsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -243,9 +239,7 @@ namespace Intuit.TSheets.Api
             LocationsMapFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetLocationsMapsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -269,11 +263,7 @@ namespace Intuit.TSheets.Api
             LocationsMapFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<LocationsMap>(EndpointName.LocationsMaps, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetLocationsMapsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,9 +291,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<LocationsMap>(EndpointName.LocationsMaps, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_ManagedClients.cs
+++ b/Intuit.TSheets/Api/DataService_ManagedClients.cs
@@ -131,7 +131,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync()
         {
-            return await GetManagedClientsAsync(null, null).ConfigureAwait(false);
+            return await GetManagedClientsAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -151,9 +151,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetManagedClientsAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -173,7 +171,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
             RequestOptions options)
         {
-            return await GetManagedClientsAsync(null, options).ConfigureAwait(false);
+            return await GetManagedClientsAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -197,9 +195,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetManagedClientsAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,7 +215,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
             ManagedClientFilter filter)
         {
-            return await GetManagedClientsAsync(filter, null).ConfigureAwait(false);
+            return await GetManagedClientsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -243,9 +239,7 @@ namespace Intuit.TSheets.Api
             ManagedClientFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetManagedClientsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -269,11 +263,7 @@ namespace Intuit.TSheets.Api
             ManagedClientFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<ManagedClient>(EndpointName.ManagedClients, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetManagedClientsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,9 +291,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<ManagedClient>(EndpointName.ManagedClients, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_ManagedClients.cs
+++ b/Intuit.TSheets/Api/DataService_ManagedClients.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -134,6 +135,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Managed Clients, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Managed Clients.
         /// </summary>
         /// <remarks>
@@ -154,6 +177,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Managed Clients, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Managed Clients.
         /// </summary>
         /// <remarks>
@@ -171,6 +220,32 @@ namespace Intuit.TSheets.Api
             ManagedClientFilter filter)
         {
             return await GetManagedClientsAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Managed Clients, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ManagedClientFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            ManagedClientFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -199,6 +274,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Managed Clients, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ManagedClientFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            ManagedClientFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_ManagedClients.cs
+++ b/Intuit.TSheets/Api/DataService_ManagedClients.cs
@@ -44,6 +44,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of managed clients available from your account,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<ManagedClient>, ResultsMeta) GetManagedClients()
+        {
+            return AsyncUtil.RunSync(() => GetManagedClientsAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Managed Clients.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -51,9 +67,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public (IList<ManagedClient>, ResultsMeta) GetManagedClients(RequestOptions options = null)
+        public (IList<ManagedClient>, ResultsMeta) GetManagedClients(
+            RequestOptions options)
         {
-            return GetManagedClients(null, options);
+            return AsyncUtil.RunSync(() => GetManagedClientsAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Managed Clients.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ManagedClientFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<ManagedClient>, ResultsMeta) GetManagedClients(
+            ManagedClientFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetManagedClientsAsync(filter));
         }
 
         /// <summary>
@@ -75,9 +112,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<ManagedClient>, ResultsMeta) GetManagedClients(
             ManagedClientFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetManagedClientsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Managed Clients.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync()
+        {
+            return await GetManagedClientsAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -94,9 +147,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(RequestOptions options = null)
+        public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            RequestOptions options)
         {
             return await GetManagedClientsAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Managed Clients.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ManagedClientFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            ManagedClientFilter filter)
+        {
+            return await GetManagedClientsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -118,7 +192,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
             ManagedClientFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<ManagedClient>(EndpointName.ManagedClients, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_Notifications.cs
+++ b/Intuit.TSheets/Api/DataService_Notifications.cs
@@ -43,24 +43,6 @@ namespace Intuit.TSheets.Api
         /// Create Notifications.
         /// </summary>
         /// <remarks>
-        /// Add one or more notifications.
-        /// </remarks>
-        /// <param name="notifications">
-        /// The set of <see cref="Notification"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Notification"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Notification>, ResultsMeta) CreateNotifications(IEnumerable<Notification> notifications)
-        {
-            return AsyncUtil.RunSync(() => CreateNotificationsAsync(notifications));
-        }
-
-        /// <summary>
-        /// Create Notifications.
-        /// </summary>
-        /// <remarks>
         /// Add a single notification.
         /// </remarks>
         /// <param name="notification">
@@ -78,7 +60,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Notifications.
+        /// Create Notifications.
         /// </summary>
         /// <remarks>
         /// Add one or more notifications.
@@ -90,39 +72,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Notification"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
-            IEnumerable<Notification> notifications)
+        public (IList<Notification>, ResultsMeta) CreateNotifications(IEnumerable<Notification> notifications)
         {
-            var context = new CreateContext<Notification>(EndpointName.Notifications, notifications);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Notifications, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more notifications.
-        /// </remarks>
-        /// <param name="notifications">
-        /// The set of <see cref="Notification"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Notification"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
-            IEnumerable<Notification> notifications,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateNotificationsAsync(notifications));
         }
 
         /// <summary>
@@ -141,7 +93,7 @@ namespace Intuit.TSheets.Api
         public async Task<(Notification, ResultsMeta)> CreateNotificationAsync(
             Notification notification)
         {
-            (IList<Notification> notifications, ResultsMeta resultsMeta) = await CreateNotificationsAsync(new[] { notification }).ConfigureAwait(false);
+            (IList<Notification> notifications, ResultsMeta resultsMeta) = await CreateNotificationsAsync(new[] { notification }, default).ConfigureAwait(false);
 
             return (notifications.FirstOrDefault(), resultsMeta);
         }
@@ -166,9 +118,55 @@ namespace Intuit.TSheets.Api
             Notification notification,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Notification> notifications, ResultsMeta resultsMeta) = await CreateNotificationsAsync(new[] { notification }, cancellationToken).ConfigureAwait(false);
+
+            return (notifications.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more notifications.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Notification"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
+            IEnumerable<Notification> notifications)
+        {
+            return await CreateNotificationsAsync(notifications, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more notifications.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Notification"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
+            IEnumerable<Notification> notifications,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<Notification>(EndpointName.Notifications, notifications);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -268,7 +266,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync()
         {
-            return await GetNotificationsAsync(null, null).ConfigureAwait(false);
+            return await GetNotificationsAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -288,9 +286,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetNotificationsAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -310,7 +306,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
             RequestOptions options)
         {
-            return await GetNotificationsAsync(null, options).ConfigureAwait(false);
+            return await GetNotificationsAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -334,9 +330,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetNotificationsAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -356,7 +350,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
             NotificationFilter filter)
         {
-            return await GetNotificationsAsync(filter, null).ConfigureAwait(false);
+            return await GetNotificationsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -380,9 +374,7 @@ namespace Intuit.TSheets.Api
             NotificationFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetNotificationsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -406,11 +398,7 @@ namespace Intuit.TSheets.Api
             NotificationFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<Notification>(EndpointName.Notifications, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetNotificationsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -438,9 +426,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<Notification>(EndpointName.Notifications, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -458,23 +448,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         public void DeleteNotification(Notification notification)
         {
-            DeleteNotifications(new[] { notification });
-        }
-
-        /// <summary>
-        /// Delete Notifications.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="Notification"/> objects.
-        /// </remarks>
-        /// <param name="notifications">
-        /// The set of <see cref="Notification"/> objects to be deleted.
-        /// </param>
-        public void DeleteNotifications(IEnumerable<Notification> notifications)
-        {
-            IEnumerable<int> ids = notifications.Select(j => j.Id);
-
-            DeleteNotifications(ids);
+            AsyncUtil.RunSync(() => DeleteNotificationAsync(notification));
         }
 
         /// <summary>
@@ -488,7 +462,21 @@ namespace Intuit.TSheets.Api
         /// </param>
         public void DeleteNotification(int id)
         {
-            DeleteNotifications(new[] { id });
+            AsyncUtil.RunSync(() => DeleteNotificationAsync(id));
+        }
+
+        /// <summary>
+        /// Delete Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Notification"/> objects.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be deleted.
+        /// </param>
+        public void DeleteNotifications(IEnumerable<Notification> notifications)
+        {
+            AsyncUtil.RunSync(() => DeleteNotificationsAsync(notifications));
         }
 
         /// <summary>
@@ -518,7 +506,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteNotificationAsync(
             Notification notification)
         {
-            await DeleteNotificationsAsync(new[] { notification }).ConfigureAwait(false);
+            await DeleteNotificationsAsync(new[] { notification.Id }, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -538,49 +526,7 @@ namespace Intuit.TSheets.Api
             Notification notification,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
-        }
-
-        /// <summary>
-        /// Asynchronously Delete Notifications.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="Notification"/> objects.
-        /// </remarks>
-        /// <param name="notifications">
-        /// The set of <see cref="Notification"/> objects to be deleted.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        public async Task DeleteNotificationsAsync(
-            IEnumerable<Notification> notifications)
-        {
-            IEnumerable<int> ids = notifications.Select(t => t.Id);
-
-            await DeleteNotificationsAsync(ids).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Asynchronously Delete Notifications, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="Notification"/> objects.
-        /// </remarks>
-        /// <param name="notifications">
-        /// The set of <see cref="Notification"/> objects to be deleted.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        public async Task DeleteNotificationsAsync(
-            IEnumerable<Notification> notifications,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            await DeleteNotificationsAsync(new[] { notification.Id }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -596,7 +542,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteNotificationAsync(
             int id)
         {
-            await DeleteNotificationsAsync(new[] { id }).ConfigureAwait(false);
+            await DeleteNotificationsAsync(new[] { id }, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -616,9 +562,47 @@ namespace Intuit.TSheets.Api
             int id,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            await DeleteNotificationsAsync(new[] { id }, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Notification"/> objects.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be deleted.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteNotificationsAsync(
+            IEnumerable<Notification> notifications)
+        {
+            IEnumerable<int> ids = notifications.Select(t => t.Id);
+
+            await DeleteNotificationsAsync(ids, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Notification"/> objects.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteNotificationsAsync(
+            IEnumerable<Notification> notifications,
+            CancellationToken cancellationToken)
+        {
+            IEnumerable<int> ids = notifications.Select(t => t.Id);
+
+            await DeleteNotificationsAsync(ids, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -634,9 +618,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteNotificationsAsync(
             IEnumerable<int> ids)
         {
-            var context = new DeleteContext<Notification>(EndpointName.Notifications, ids);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
+            await DeleteNotificationsAsync(ids, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -656,9 +638,9 @@ namespace Intuit.TSheets.Api
             IEnumerable<int> ids,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new DeleteContext<Notification>(EndpointName.Notifications, ids);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Notifications.cs
+++ b/Intuit.TSheets/Api/DataService_Notifications.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -89,13 +90,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Notification"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(IEnumerable<Notification> notifications)
+        public async Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
+            IEnumerable<Notification> notifications)
         {
             var context = new CreateContext<Notification>(EndpointName.Notifications, notifications);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more notifications.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Notification"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
+            IEnumerable<Notification> notifications,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -111,17 +138,43 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Notification"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Notification, ResultsMeta)> CreateNotificationAsync(Notification notification)
+        public async Task<(Notification, ResultsMeta)> CreateNotificationAsync(
+            Notification notification)
         {
             (IList<Notification> notifications, ResultsMeta resultsMeta) = await CreateNotificationsAsync(new[] { notification }).ConfigureAwait(false);
 
             return (notifications.FirstOrDefault(), resultsMeta);
         }
 
+        /// <summary>
+        /// Asynchronously Create Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single notification.
+        /// </remarks>
+        /// <param name="notification">
+        /// The <see cref="Notification"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Notification"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Notification, ResultsMeta)> CreateNotificationAsync(
+            Notification notification,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
         #endregion
 
         #region Get Methods
-        
+
         /// <summary>
         /// Retrieve Notifications.
         /// </summary>
@@ -219,6 +272,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Notifications.
         /// </summary>
         /// <remarks>
@@ -239,6 +314,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Notifications.
         /// </summary>
         /// <remarks>
@@ -256,6 +357,32 @@ namespace Intuit.TSheets.Api
             NotificationFilter filter)
         {
             return await GetNotificationsAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="NotificationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            NotificationFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -284,6 +411,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="NotificationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            NotificationFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -358,9 +515,32 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Notification"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteNotificationAsync(Notification notification)
+        public async Task DeleteNotificationAsync(
+            Notification notification)
         {
             await DeleteNotificationsAsync(new[] { notification }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="Notification"/> object.
+        /// </remarks>
+        /// <param name="notification">
+        /// The <see cref="Notification"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteNotificationAsync(
+            Notification notification,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -373,11 +553,34 @@ namespace Intuit.TSheets.Api
         /// The set of <see cref="Notification"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteNotificationsAsync(IEnumerable<Notification> notifications)
+        public async Task DeleteNotificationsAsync(
+            IEnumerable<Notification> notifications)
         {
             IEnumerable<int> ids = notifications.Select(t => t.Id);
 
             await DeleteNotificationsAsync(ids).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Notification"/> objects.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteNotificationsAsync(
+            IEnumerable<Notification> notifications,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -390,9 +593,32 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="Notification"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteNotificationAsync(int id)
+        public async Task DeleteNotificationAsync(
+            int id)
         {
             await DeleteNotificationsAsync(new[] { id }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="Notification"/> object, by id.
+        /// </remarks>
+        /// <param name="id">
+        /// The id of the <see cref="Notification"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteNotificationAsync(
+            int id,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -405,11 +631,34 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="Notification"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteNotificationsAsync(IEnumerable<int> ids)
+        public async Task DeleteNotificationsAsync(
+            IEnumerable<int> ids)
         {
             var context = new DeleteContext<Notification>(EndpointName.Notifications, ids);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Notification"/> objects, by id.
+        /// </remarks>
+        /// <param name="ids">
+        /// The set of ids for the <see cref="Notification"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteNotificationsAsync(
+            IEnumerable<int> ids,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Notifications.cs
+++ b/Intuit.TSheets/Api/DataService_Notifications.cs
@@ -129,6 +129,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all notifications associated with your company,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<Notification>, ResultsMeta) GetNotifications()
+        {
+            return AsyncUtil.RunSync(() => GetNotificationsAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -136,9 +152,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Notification"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public (IList<Notification>, ResultsMeta) GetNotifications(RequestOptions options = null)
+        public (IList<Notification>, ResultsMeta) GetNotifications(
+            RequestOptions options)
         {
-            return GetNotifications(null, options);
+            return AsyncUtil.RunSync(() => GetNotificationsAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="NotificationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<Notification>, ResultsMeta) GetNotifications(
+            NotificationFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetNotificationsAsync(filter));
         }
 
         /// <summary>
@@ -160,9 +197,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<Notification>, ResultsMeta) GetNotifications(
             NotificationFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetNotificationsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync()
+        {
+            return await GetNotificationsAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -179,9 +232,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Notification"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(RequestOptions options = null)
+        public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            RequestOptions options)
         {
             return await GetNotificationsAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="NotificationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            NotificationFilter filter)
+        {
+            return await GetNotificationsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -203,7 +277,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
             NotificationFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<Notification>(EndpointName.Notifications, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_Reminders.cs
+++ b/Intuit.TSheets/Api/DataService_Reminders.cs
@@ -132,6 +132,26 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="ReminderFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Reminder"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<Reminder>, ResultsMeta) GetReminders(
+            ReminderFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetRemindersAsync(filter));
+        }
+
+        /// <summary>
+        /// Retrieve Reminders.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all reminders associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ReminderFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -141,9 +161,29 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<Reminder>, ResultsMeta) GetReminders(
             ReminderFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetRemindersAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Reminders.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all reminders associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ReminderFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Reminder"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Reminder>, ResultsMeta)> GetRemindersAsync(
+            ReminderFilter filter)
+        {
+            return await GetRemindersAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -165,7 +205,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<Reminder>, ResultsMeta)> GetRemindersAsync(
             ReminderFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<Reminder>(EndpointName.Reminders, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_Reminders.cs
+++ b/Intuit.TSheets/Api/DataService_Reminders.cs
@@ -43,24 +43,6 @@ namespace Intuit.TSheets.Api
         /// Create Reminders.
         /// </summary>
         /// <remarks>
-        /// Add one or more user-specific or company-wide reminders.
-        /// </remarks>
-        /// <param name="reminders">
-        /// The set of <see cref="Reminder"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Reminder"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Reminder>, ResultsMeta) CreateReminders(IEnumerable<Reminder> reminders)
-        {
-            return AsyncUtil.RunSync(() => CreateRemindersAsync(reminders));
-        }
-        
-        /// <summary>
-        /// Create Reminders.
-        /// </summary>
-        /// <remarks>
         /// Add a single user-specific or company-wide reminder.
         /// </remarks>
         /// <param name="reminder">
@@ -78,7 +60,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Reminders.
+        /// Create Reminders.
         /// </summary>
         /// <remarks>
         /// Add one or more user-specific or company-wide reminders.
@@ -90,39 +72,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Reminder"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
-            IEnumerable<Reminder> reminders)
+        public (IList<Reminder>, ResultsMeta) CreateReminders(IEnumerable<Reminder> reminders)
         {
-            var context = new CreateContext<Reminder>(EndpointName.Reminders, reminders);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Reminders, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more user-specific or company-wide reminders.
-        /// </remarks>
-        /// <param name="reminders">
-        /// The set of <see cref="Reminder"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Reminder"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
-            IEnumerable<Reminder> reminders,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateRemindersAsync(reminders));
         }
 
         /// <summary>
@@ -141,7 +93,7 @@ namespace Intuit.TSheets.Api
         public async Task<(Reminder, ResultsMeta)> CreateReminderAsync(
             Reminder reminder)
         {
-            (IList<Reminder> reminders, ResultsMeta resultsMeta) = await CreateRemindersAsync(new[] { reminder }).ConfigureAwait(false);
+            (IList<Reminder> reminders, ResultsMeta resultsMeta) = await CreateRemindersAsync(new[] { reminder }, default).ConfigureAwait(false);
 
             return (reminders.FirstOrDefault(), resultsMeta);
         }
@@ -166,9 +118,55 @@ namespace Intuit.TSheets.Api
             Reminder reminder,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Reminder> reminders, ResultsMeta resultsMeta) = await CreateRemindersAsync(new[] { reminder }, cancellationToken).ConfigureAwait(false);
+
+            return (reminders.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Reminders.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more user-specific or company-wide reminders.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
+            IEnumerable<Reminder> reminders)
+        {
+            return await CreateRemindersAsync(reminders, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more user-specific or company-wide reminders.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
+            IEnumerable<Reminder> reminders,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<Reminder>(EndpointName.Reminders, reminders);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -236,7 +234,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Reminder>, ResultsMeta)> GetRemindersAsync(
             ReminderFilter filter)
         {
-            return await GetRemindersAsync(filter, null).ConfigureAwait(false);
+            return await GetRemindersAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -260,9 +258,7 @@ namespace Intuit.TSheets.Api
             ReminderFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetRemindersAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -286,11 +282,7 @@ namespace Intuit.TSheets.Api
             ReminderFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<Reminder>(EndpointName.Reminders, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetRemindersAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -318,32 +310,16 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<Reminder>(EndpointName.Reminders, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
 
         #region Update methods
-
-        /// <summary>
-        /// Update Reminders.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more reminders for employees within your company.
-        /// </remarks>
-        /// <param name="reminders">
-        /// The set of <see cref="Reminder"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Reminder"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Reminder>, ResultsMeta) UpdateReminders(IEnumerable<Reminder> reminders)
-        {
-            return AsyncUtil.RunSync(() => UpdateRemindersAsync(reminders));
-        }
 
         /// <summary>
         /// Update Reminders.
@@ -367,7 +343,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Update Reminders.
+        /// Update Reminders.
         /// </summary>
         /// <remarks>
         /// Edit one or more reminders for employees within your company.
@@ -379,39 +355,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Reminder"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Reminder>, ResultsMeta)> UpdateRemindersAsync(
-            IEnumerable<Reminder> reminders)
+        public (IList<Reminder>, ResultsMeta) UpdateReminders(IEnumerable<Reminder> reminders)
         {
-            var context = new UpdateContext<Reminder>(EndpointName.Reminders, reminders);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Update Reminders, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more reminders for employees within your company.
-        /// </remarks>
-        /// <param name="reminders">
-        /// The set of <see cref="Reminder"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Reminder"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Reminder>, ResultsMeta)> UpdateRemindersAsync(
-            IEnumerable<Reminder> reminders,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => UpdateRemindersAsync(reminders));
         }
 
         /// <summary>
@@ -431,7 +377,7 @@ namespace Intuit.TSheets.Api
             Reminder reminder)
         {
             (IList<Reminder> reminders, ResultsMeta resultsMeta) =
-                await UpdateRemindersAsync(new[] { reminder }).ConfigureAwait(false);
+                await UpdateRemindersAsync(new[] { reminder }, default).ConfigureAwait(false);
 
             return (reminders.FirstOrDefault(), resultsMeta);
         }
@@ -456,9 +402,56 @@ namespace Intuit.TSheets.Api
             Reminder reminder,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Reminder> reminders, ResultsMeta resultsMeta) =
+                await UpdateRemindersAsync(new[] { reminder }, cancellationToken).ConfigureAwait(false);
+
+            return (reminders.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Reminders.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more reminders for employees within your company.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Reminder>, ResultsMeta)> UpdateRemindersAsync(
+            IEnumerable<Reminder> reminders)
+        {
+            return await UpdateRemindersAsync(reminders, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more reminders for employees within your company.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Reminder>, ResultsMeta)> UpdateRemindersAsync(
+            IEnumerable<Reminder> reminders,
+            CancellationToken cancellationToken)
+        {
+            var context = new UpdateContext<Reminder>(EndpointName.Reminders, reminders);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Reminders.cs
+++ b/Intuit.TSheets/Api/DataService_Reminders.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -89,13 +90,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Reminder"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(IEnumerable<Reminder> reminders)
+        public async Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
+            IEnumerable<Reminder> reminders)
         {
             var context = new CreateContext<Reminder>(EndpointName.Reminders, reminders);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more user-specific or company-wide reminders.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
+            IEnumerable<Reminder> reminders,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -111,11 +138,37 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Reminder"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Reminder, ResultsMeta)> CreateReminderAsync(Reminder reminder)
+        public async Task<(Reminder, ResultsMeta)> CreateReminderAsync(
+            Reminder reminder)
         {
             (IList<Reminder> reminders, ResultsMeta resultsMeta) = await CreateRemindersAsync(new[] { reminder }).ConfigureAwait(false);
 
             return (reminders.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single user-specific or company-wide reminder.
+        /// </remarks>
+        /// <param name="reminder">
+        /// The <see cref="Reminder"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Reminder"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Reminder, ResultsMeta)> CreateReminderAsync(
+            Reminder reminder,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -187,6 +240,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all reminders associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ReminderFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Reminder"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Reminder>, ResultsMeta)> GetRemindersAsync(
+            ReminderFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Reminders.
         /// </summary>
         /// <remarks>
@@ -212,6 +291,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all reminders associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ReminderFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Reminder"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Reminder>, ResultsMeta)> GetRemindersAsync(
+            ReminderFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -281,6 +390,31 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Update Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more reminders for employees within your company.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Reminder>, ResultsMeta)> UpdateRemindersAsync(
+            IEnumerable<Reminder> reminders,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Update Reminders.
         /// </summary>
         /// <remarks>
@@ -293,12 +427,38 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Reminder"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Reminder, ResultsMeta)> UpdateReminderAsync(Reminder reminder)
+        public async Task<(Reminder, ResultsMeta)> UpdateReminderAsync(
+            Reminder reminder)
         {
             (IList<Reminder> reminders, ResultsMeta resultsMeta) =
                 await UpdateRemindersAsync(new[] { reminder }).ConfigureAwait(false);
 
             return (reminders.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single reminder for employees within your company.
+        /// </remarks>
+        /// <param name="reminder">
+        /// The <see cref="Reminder"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Reminder"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Reminder, ResultsMeta)> UpdateReminderAsync(
+            Reminder reminder,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Reports.cs
+++ b/Intuit.TSheets/Api/DataService_Reports.cs
@@ -85,7 +85,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         public async Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync()
         {
-            return await GetCurrentTotalsReportAsync(null).ConfigureAwait(false);
+            return await GetCurrentTotalsReportAsync(null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -105,9 +105,7 @@ namespace Intuit.TSheets.Api
         public async Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetCurrentTotalsReportAsync(null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -127,11 +125,7 @@ namespace Intuit.TSheets.Api
         public async Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync(
             CurrentTotalsReportFilter filter)
         {
-            var context = new GetReportContext<CurrentTotalsReport>(EndpointName.CurrentTotalsReports, filter);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results, context.ResultsMeta);
+            return await GetCurrentTotalsReportAsync(filter, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -155,9 +149,11 @@ namespace Intuit.TSheets.Api
             CurrentTotalsReportFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetReportContext<CurrentTotalsReport>(EndpointName.CurrentTotalsReports, filter);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results, context.ResultsMeta);
         }
 
         #endregion
@@ -200,11 +196,7 @@ namespace Intuit.TSheets.Api
         public async Task<(PayrollReport, ResultsMeta)> GetPayrollReportAsync(
             PayrollReportFilter filter)
         {
-            var context = new GetReportContext<PayrollReport>(EndpointName.PayrollReports, filter);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results, context.ResultsMeta);
+            return await GetPayrollReportAsync(filter, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -228,9 +220,11 @@ namespace Intuit.TSheets.Api
             PayrollReportFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetReportContext<PayrollReport>(EndpointName.PayrollReports, filter);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results, context.ResultsMeta);
         }
 
         #endregion
@@ -273,11 +267,7 @@ namespace Intuit.TSheets.Api
         public async Task<(PayrollByJobcodeReport, ResultsMeta)> GetPayrollByJobcodeReportAsync(
             PayrollByJobcodeReportFilter filter)
         {
-            var context = new GetReportContext<PayrollByJobcodeReport>(EndpointName.PayrollByJobcodeReports, filter);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results, context.ResultsMeta);
+            return await GetPayrollByJobcodeReportAsync(filter, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,9 +291,11 @@ namespace Intuit.TSheets.Api
             PayrollByJobcodeReportFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetReportContext<PayrollByJobcodeReport>(EndpointName.PayrollByJobcodeReports, filter);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results, context.ResultsMeta);
         }
 
         #endregion
@@ -344,11 +336,7 @@ namespace Intuit.TSheets.Api
         public async Task<(ProjectReport, ResultsMeta)> GetProjectReportAsync(
             ProjectReportFilter filter)
         {
-            var context = new GetReportContext<ProjectReport>(EndpointName.ProjectReports, filter);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results, context.ResultsMeta);
+            return await GetProjectReportAsync(filter, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -371,9 +359,11 @@ namespace Intuit.TSheets.Api
             ProjectReportFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetReportContext<ProjectReport>(EndpointName.ProjectReports, filter);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Reports.cs
+++ b/Intuit.TSheets/Api/DataService_Reports.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Api
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -88,6 +89,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Current Totals Report, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a snapshot report for the current totals (shift and day) along with additional
+        /// information provided for those who are currently on the clock.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="CurrentTotalsReport"/> class, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Current Totals Report.
         /// </summary>
         /// <remarks>
@@ -101,13 +124,40 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="CurrentTotalsReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync(CurrentTotalsReportFilter filter)
+        public async Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync(
+            CurrentTotalsReportFilter filter)
         {
             var context = new GetReportContext<CurrentTotalsReport>(EndpointName.CurrentTotalsReports, filter);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Current Totals Report, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a snapshot report for the current totals (shift and day) along with additional
+        /// information provided for those who are currently on the clock.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CurrentTotalsReportFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="CurrentTotalsReport"/> class, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync(
+            CurrentTotalsReportFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -147,13 +197,40 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="PayrollReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(PayrollReport, ResultsMeta)> GetPayrollReportAsync(PayrollReportFilter filter)
+        public async Task<(PayrollReport, ResultsMeta)> GetPayrollReportAsync(
+            PayrollReportFilter filter)
         {
             var context = new GetReportContext<PayrollReport>(EndpointName.PayrollReports, filter);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Payroll Report, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a payroll report associated with a time frame,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="PayrollReportFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="PayrollReport"/> class, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(PayrollReport, ResultsMeta)> GetPayrollReportAsync(
+            PayrollReportFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -193,13 +270,40 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="PayrollByJobcodeReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(PayrollByJobcodeReport, ResultsMeta)> GetPayrollByJobcodeReportAsync(PayrollByJobcodeReportFilter filter)
+        public async Task<(PayrollByJobcodeReport, ResultsMeta)> GetPayrollByJobcodeReportAsync(
+            PayrollByJobcodeReportFilter filter)
         {
             var context = new GetReportContext<PayrollByJobcodeReport>(EndpointName.PayrollByJobcodeReports, filter);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Payroll by Jobcode Report, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a payroll report, broken down by jobcode,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="PayrollByJobcodeReportFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="PayrollByJobcodeReport"/> class, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(PayrollByJobcodeReport, ResultsMeta)> GetPayrollByJobcodeReportAsync(
+            PayrollByJobcodeReportFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -237,13 +341,39 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="ProjectReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(ProjectReport, ResultsMeta)> GetProjectReportAsync(ProjectReportFilter filter)
+        public async Task<(ProjectReport, ResultsMeta)> GetProjectReportAsync(
+            ProjectReportFilter filter)
         {
             var context = new GetReportContext<ProjectReport>(EndpointName.ProjectReports, filter);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Project Report, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a project report with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ProjectReportFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="ProjectReport"/> class, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(ProjectReport, ResultsMeta)> GetProjectReportAsync(
+            ProjectReportFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_ScheduleCalendars.cs
+++ b/Intuit.TSheets/Api/DataService_ScheduleCalendars.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -134,6 +135,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Schedule Calendars.
         /// </summary>
         /// <remarks>
@@ -154,6 +177,31 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars, with support for cancellation.
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Schedule Calendars.
         /// </summary>
         /// <remarks>
@@ -171,6 +219,32 @@ namespace Intuit.TSheets.Api
             ScheduleCalendarFilter filter)
         {
             return await GetScheduleCalendarsAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleCalendarFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            ScheduleCalendarFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -199,6 +273,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleCalendarFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            ScheduleCalendarFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_ScheduleCalendars.cs
+++ b/Intuit.TSheets/Api/DataService_ScheduleCalendars.cs
@@ -131,7 +131,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync()
         {
-            return await GetScheduleCalendarsAsync(null, null).ConfigureAwait(false);
+            return await GetScheduleCalendarsAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -151,9 +151,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetScheduleCalendarsAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -173,7 +171,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
             RequestOptions options)
         {
-            return await GetScheduleCalendarsAsync(null, options).ConfigureAwait(false);
+            return await GetScheduleCalendarsAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -196,9 +194,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetScheduleCalendarsAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -218,7 +214,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
             ScheduleCalendarFilter filter)
         {
-            return await GetScheduleCalendarsAsync(filter, null).ConfigureAwait(false);
+            return await GetScheduleCalendarsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -242,9 +238,7 @@ namespace Intuit.TSheets.Api
             ScheduleCalendarFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetScheduleCalendarsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -268,11 +262,7 @@ namespace Intuit.TSheets.Api
             ScheduleCalendarFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<ScheduleCalendar>(EndpointName.ScheduleCalendars, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetScheduleCalendarsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -300,9 +290,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<ScheduleCalendar>(EndpointName.ScheduleCalendars, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_ScheduleCalendars.cs
+++ b/Intuit.TSheets/Api/DataService_ScheduleCalendars.cs
@@ -44,6 +44,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all schedule calendars associated with your
         /// employees, with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<ScheduleCalendar>, ResultsMeta) GetScheduleCalendars()
+        {
+            return AsyncUtil.RunSync(() => GetScheduleCalendarsAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Schedule Calendars.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -51,9 +67,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public (IList<ScheduleCalendar>, ResultsMeta) GetScheduleCalendars(RequestOptions options = null)
+        public (IList<ScheduleCalendar>, ResultsMeta) GetScheduleCalendars(
+            RequestOptions options)
         {
-            return GetScheduleCalendars(null, options);
+            return AsyncUtil.RunSync(() => GetScheduleCalendarsAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Schedule Calendars.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleCalendarFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<ScheduleCalendar>, ResultsMeta) GetScheduleCalendars(
+            ScheduleCalendarFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetScheduleCalendarsAsync(filter));
         }
 
         /// <summary>
@@ -75,9 +112,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<ScheduleCalendar>, ResultsMeta) GetScheduleCalendars(
             ScheduleCalendarFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetScheduleCalendarsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync()
+        {
+            return await GetScheduleCalendarsAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -94,9 +147,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(RequestOptions options = null)
+        public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            RequestOptions options)
         {
             return await GetScheduleCalendarsAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleCalendarFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            ScheduleCalendarFilter filter)
+        {
+            return await GetScheduleCalendarsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -118,7 +192,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
             ScheduleCalendarFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<ScheduleCalendar>(EndpointName.ScheduleCalendars, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_ScheduleEvents.cs
+++ b/Intuit.TSheets/Api/DataService_ScheduleEvents.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -89,13 +90,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(IEnumerable<ScheduleEvent> scheduleEvents)
+        public async Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents)
         {
             var context = new CreateContext<ScheduleEvent>(EndpointName.ScheduleEvents, scheduleEvents);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Schedule Events.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -111,11 +138,37 @@ namespace Intuit.TSheets.Api
         /// The <see cref="ScheduleEvent"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(ScheduleEvent, ResultsMeta)> CreateScheduleEventAsync(ScheduleEvent scheduleEvent)
+        public async Task<(ScheduleEvent, ResultsMeta)> CreateScheduleEventAsync(
+            ScheduleEvent scheduleEvent)
         {
             (IList<ScheduleEvent> scheduleEvents, ResultsMeta resultsMeta) = await CreateScheduleEventsAsync(new[] { scheduleEvent }).ConfigureAwait(false);
 
             return (scheduleEvents.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create ScheduleEvents, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single schedule event.
+        /// </remarks>
+        /// <param name="scheduleEvent">
+        /// The <see cref="ScheduleEvent"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ScheduleEvent"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(ScheduleEvent, ResultsMeta)> CreateScheduleEventAsync(
+            ScheduleEvent scheduleEvent,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -187,6 +240,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Schedule Events, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule events associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleEventFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleEvent"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ScheduleEvent>, ResultsMeta)> GetScheduleEventsAsync(
+            ScheduleEventFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Schedule Events.
         /// </summary>
         /// <remarks>
@@ -212,6 +291,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Events, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule events associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleEventFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleEvent"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ScheduleEvent>, ResultsMeta)> GetScheduleEventsAsync(
+            ScheduleEventFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -282,6 +391,31 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Update ScheduleEvents, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<ScheduleEvent>, ResultsMeta)> UpdateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Update ScheduleEvents.
         /// </summary>
         /// <remarks>
@@ -301,6 +435,31 @@ namespace Intuit.TSheets.Api
                 await UpdateScheduleEventsAsync(new[] { scheduleEvent }).ConfigureAwait(false);
 
             return (scheduleEvents.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update ScheduleEvents, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single schedule event.
+        /// </remarks>
+        /// <param name="scheduleEvent">
+        /// The <see cref="ScheduleEvent"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ScheduleEvent"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(ScheduleEvent, ResultsMeta)> UpdateScheduleEventAsync(
+            ScheduleEvent scheduleEvent,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_ScheduleEvents.cs
+++ b/Intuit.TSheets/Api/DataService_ScheduleEvents.cs
@@ -132,6 +132,26 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="ScheduleEventFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleEvent"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<ScheduleEvent>, ResultsMeta) GetScheduleEvents(
+            ScheduleEventFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetScheduleEventsAsync(filter));
+        }
+
+        /// <summary>
+        /// Retrieve Schedule Events.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule events associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleEventFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -141,9 +161,29 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<ScheduleEvent>, ResultsMeta) GetScheduleEvents(
             ScheduleEventFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetScheduleEventsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Events.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule events associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleEventFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleEvent"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<ScheduleEvent>, ResultsMeta)> GetScheduleEventsAsync(
+            ScheduleEventFilter filter)
+        {
+            return await GetScheduleEventsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -165,7 +205,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<ScheduleEvent>, ResultsMeta)> GetScheduleEventsAsync(
             ScheduleEventFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<ScheduleEvent>(EndpointName.ScheduleEvents, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_ScheduleEvents.cs
+++ b/Intuit.TSheets/Api/DataService_ScheduleEvents.cs
@@ -40,24 +40,6 @@ namespace Intuit.TSheets.Api
         #region Create methods
 
         /// <summary>
-        /// Create Schedule Events.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more schedule events.
-        /// </remarks>
-        /// <param name="scheduleEvents">
-        /// The set of <see cref="ScheduleEvent"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<ScheduleEvent>, ResultsMeta) CreateScheduleEvents(IEnumerable<ScheduleEvent> scheduleEvents)
-        {
-            return AsyncUtil.RunSync(() => CreateScheduleEventsAsync(scheduleEvents));
-        }
-
-        /// <summary>
         /// Create ScheduleEvents.
         /// </summary>
         /// <remarks>
@@ -78,7 +60,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Schedule Events.
+        /// Create Schedule Events.
         /// </summary>
         /// <remarks>
         /// Add one or more schedule events.
@@ -90,39 +72,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
-            IEnumerable<ScheduleEvent> scheduleEvents)
+        public (IList<ScheduleEvent>, ResultsMeta) CreateScheduleEvents(IEnumerable<ScheduleEvent> scheduleEvents)
         {
-            var context = new CreateContext<ScheduleEvent>(EndpointName.ScheduleEvents, scheduleEvents);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Schedule Events.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more schedule events.
-        /// </remarks>
-        /// <param name="scheduleEvents">
-        /// The set of <see cref="ScheduleEvent"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
-            IEnumerable<ScheduleEvent> scheduleEvents,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateScheduleEventsAsync(scheduleEvents));
         }
 
         /// <summary>
@@ -141,7 +93,7 @@ namespace Intuit.TSheets.Api
         public async Task<(ScheduleEvent, ResultsMeta)> CreateScheduleEventAsync(
             ScheduleEvent scheduleEvent)
         {
-            (IList<ScheduleEvent> scheduleEvents, ResultsMeta resultsMeta) = await CreateScheduleEventsAsync(new[] { scheduleEvent }).ConfigureAwait(false);
+            (IList<ScheduleEvent> scheduleEvents, ResultsMeta resultsMeta) = await CreateScheduleEventsAsync(new[] { scheduleEvent }, default).ConfigureAwait(false);
 
             return (scheduleEvents.FirstOrDefault(), resultsMeta);
         }
@@ -166,9 +118,55 @@ namespace Intuit.TSheets.Api
             ScheduleEvent scheduleEvent,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<ScheduleEvent> scheduleEvents, ResultsMeta resultsMeta) = await CreateScheduleEventsAsync(new[] { scheduleEvent }, cancellationToken).ConfigureAwait(false);
+
+            return (scheduleEvents.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Schedule Events.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents)
+        {
+            return await CreateScheduleEventsAsync(scheduleEvents, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Schedule Events.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<ScheduleEvent>(EndpointName.ScheduleEvents, scheduleEvents);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -236,7 +234,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<ScheduleEvent>, ResultsMeta)> GetScheduleEventsAsync(
             ScheduleEventFilter filter)
         {
-            return await GetScheduleEventsAsync(filter, null).ConfigureAwait(false);
+            return await GetScheduleEventsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -260,9 +258,7 @@ namespace Intuit.TSheets.Api
             ScheduleEventFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetScheduleEventsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -286,11 +282,7 @@ namespace Intuit.TSheets.Api
             ScheduleEventFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<ScheduleEvent>(EndpointName.ScheduleEvents, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetScheduleEventsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -318,32 +310,16 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<ScheduleEvent>(EndpointName.ScheduleEvents, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
 
         #region Update methods
-
-        /// <summary>
-        /// Update Schedule Events.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more schedule events.
-        /// </remarks>
-        /// <param name="scheduleEvents">
-        /// The set of <see cref="ScheduleEvent"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<ScheduleEvent>, ResultsMeta) UpdateScheduleEvents(IEnumerable<ScheduleEvent> scheduleEvents)
-        {
-            return AsyncUtil.RunSync(() => UpdateScheduleEventsAsync(scheduleEvents));
-        }
 
         /// <summary>
         /// Update ScheduleEvents.
@@ -368,7 +344,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Update ScheduleEvents.
+        /// Update Schedule Events.
         /// </summary>
         /// <remarks>
         /// Edit one or more schedule events.
@@ -380,39 +356,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<ScheduleEvent>, ResultsMeta)> UpdateScheduleEventsAsync(
-            IEnumerable<ScheduleEvent> scheduleEvents)
+        public (IList<ScheduleEvent>, ResultsMeta) UpdateScheduleEvents(IEnumerable<ScheduleEvent> scheduleEvents)
         {
-            var context = new UpdateContext<ScheduleEvent>(EndpointName.ScheduleEvents, scheduleEvents);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Update ScheduleEvents, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more schedule events.
-        /// </remarks>
-        /// <param name="scheduleEvents">
-        /// The set of <see cref="ScheduleEvent"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<ScheduleEvent>, ResultsMeta)> UpdateScheduleEventsAsync(
-            IEnumerable<ScheduleEvent> scheduleEvents,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => UpdateScheduleEventsAsync(scheduleEvents));
         }
 
         /// <summary>
@@ -432,7 +378,7 @@ namespace Intuit.TSheets.Api
             ScheduleEvent scheduleEvent)
         {
             (IList<ScheduleEvent> scheduleEvents, ResultsMeta resultsMeta) =
-                await UpdateScheduleEventsAsync(new[] { scheduleEvent }).ConfigureAwait(false);
+                await UpdateScheduleEventsAsync(new[] { scheduleEvent }, default).ConfigureAwait(false);
 
             return (scheduleEvents.FirstOrDefault(), resultsMeta);
         }
@@ -457,9 +403,56 @@ namespace Intuit.TSheets.Api
             ScheduleEvent scheduleEvent,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<ScheduleEvent> scheduleEvents, ResultsMeta resultsMeta) =
+                await UpdateScheduleEventsAsync(new[] { scheduleEvent }, cancellationToken).ConfigureAwait(false);
+
+            return (scheduleEvents.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update ScheduleEvents.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<ScheduleEvent>, ResultsMeta)> UpdateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents)
+        {
+            return await UpdateScheduleEventsAsync(scheduleEvents, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Update ScheduleEvents, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<ScheduleEvent>, ResultsMeta)> UpdateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents,
+            CancellationToken cancellationToken)
+        {
+            var context = new UpdateContext<ScheduleEvent>(EndpointName.ScheduleEvents, scheduleEvents);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Timesheet.cs
+++ b/Intuit.TSheets/Api/DataService_Timesheet.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -89,13 +90,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Timesheet"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(IEnumerable<Timesheet> timesheets)
+        public async Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets)
         {
             var context = new CreateContext<Timesheet>(EndpointName.Timesheets, timesheets);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more timesheets to your company.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Timesheet"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -111,11 +138,37 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Timesheet"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(Timesheet, ResultsMeta)> CreateTimesheetAsync(Timesheet timesheet)
+        public async Task<(Timesheet, ResultsMeta)> CreateTimesheetAsync(
+            Timesheet timesheet)
         {
             (IList<Timesheet> timesheets, ResultsMeta resultsMeta) = await CreateTimesheetsAsync(new[] { timesheet }).ConfigureAwait(false);
 
             return (timesheets.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single timesheet to your company.
+        /// </remarks>
+        /// <param name="timesheet">
+        /// The <see cref="Timesheet"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Timesheet"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Timesheet, ResultsMeta)> CreateTimesheetAsync(
+            Timesheet timesheet,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -187,6 +240,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Timesheet"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Timesheet>, ResultsMeta)> GetTimesheetsAsync(
+            TimesheetFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Timesheets.
         /// </summary>
         /// <remarks>
@@ -212,6 +291,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Timesheet"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Timesheet>, ResultsMeta)> GetTimesheetsAsync(
+            TimesheetFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -282,6 +391,31 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Update Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more timesheets in your company.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Timesheet"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Timesheet>, ResultsMeta)> UpdateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Update Timesheets.
         /// </summary>
         /// <remarks>
@@ -301,6 +435,31 @@ namespace Intuit.TSheets.Api
                 await UpdateTimesheetsAsync(new[] { timesheet }).ConfigureAwait(false);
 
             return (timesheets.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single timesheet in your company.
+        /// </remarks>
+        /// <param name="timesheet">
+        /// The <see cref="Timesheet"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Timesheet"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(Timesheet, ResultsMeta)> UpdateTimesheetAsync(
+            Timesheet timesheet,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -375,9 +534,32 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Timesheet"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteTimesheetAsync(Timesheet timesheet)
+        public async Task DeleteTimesheetAsync(
+            Timesheet timesheet)
         {
             await DeleteTimesheetsAsync(new[] { timesheet }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="Timesheet"/> object.
+        /// </remarks>
+        /// <param name="timesheet">
+        /// The <see cref="Timesheet"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteTimesheetAsync(
+            Timesheet timesheet,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -390,11 +572,34 @@ namespace Intuit.TSheets.Api
         /// The set of <see cref="Timesheet"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteTimesheetsAsync(IEnumerable<Timesheet> timesheets)
+        public async Task DeleteTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets)
         {
             IEnumerable<int> ids = timesheets.Select(t => t.Id);
 
             await DeleteTimesheetsAsync(ids).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Timesheet"/> objects.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -407,9 +612,32 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="Timesheet"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteTimesheetAsync(int id)
+        public async Task DeleteTimesheetAsync(
+            int id)
         {
             await DeleteTimesheetsAsync(new[] { id }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="Timesheet"/> object, by id.
+        /// </remarks>
+        /// <param name="id">
+        /// The id of the <see cref="Timesheet"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteTimesheetAsync(
+            int id,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -422,11 +650,34 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="Timesheet"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        public async Task DeleteTimesheetsAsync(IEnumerable<int> ids)
+        public async Task DeleteTimesheetsAsync(
+            IEnumerable<int> ids)
         {
             var context = new DeleteContext<Timesheet>(EndpointName.Timesheets, ids);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Timesheet"/> objects, by id.
+        /// </remarks>
+        /// <param name="ids">
+        /// The set of ids for the <see cref="Timesheet"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteTimesheetsAsync(
+            IEnumerable<int> ids,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Timesheet.cs
+++ b/Intuit.TSheets/Api/DataService_Timesheet.cs
@@ -132,6 +132,26 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="TimesheetFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Timesheet"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<Timesheet>, ResultsMeta) GetTimesheets(
+            TimesheetFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetTimesheetsAsync(filter));
+        }
+
+        /// <summary>
+        /// Retrieve Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -141,9 +161,29 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<Timesheet>, ResultsMeta) GetTimesheets(
             TimesheetFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetTimesheetsAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Timesheet"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<Timesheet>, ResultsMeta)> GetTimesheetsAsync(
+            TimesheetFilter filter)
+        {
+            return await GetTimesheetsAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -165,7 +205,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<Timesheet>, ResultsMeta)> GetTimesheetsAsync(
             TimesheetFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<Timesheet>(EndpointName.Timesheets, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_Timesheet.cs
+++ b/Intuit.TSheets/Api/DataService_Timesheet.cs
@@ -43,24 +43,6 @@ namespace Intuit.TSheets.Api
         /// Create Timesheets.
         /// </summary>
         /// <remarks>
-        /// Add one or more timesheets to your company.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Timesheet"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Timesheet>, ResultsMeta) CreateTimesheets(IEnumerable<Timesheet> timesheets)
-        {
-            return AsyncUtil.RunSync(() => CreateTimesheetsAsync(timesheets));
-        }
-
-        /// <summary>
-        /// Create Timesheets.
-        /// </summary>
-        /// <remarks>
         /// Add a single timesheet to your company.
         /// </remarks>
         /// <param name="timesheet">
@@ -78,7 +60,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Timesheets.
+        /// Create Timesheets.
         /// </summary>
         /// <remarks>
         /// Add one or more timesheets to your company.
@@ -90,39 +72,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Timesheet"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
-            IEnumerable<Timesheet> timesheets)
+        public (IList<Timesheet>, ResultsMeta) CreateTimesheets(IEnumerable<Timesheet> timesheets)
         {
-            var context = new CreateContext<Timesheet>(EndpointName.Timesheets, timesheets);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Timesheets, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more timesheets to your company.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Timesheet"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
-            IEnumerable<Timesheet> timesheets,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateTimesheetsAsync(timesheets));
         }
 
         /// <summary>
@@ -141,7 +93,7 @@ namespace Intuit.TSheets.Api
         public async Task<(Timesheet, ResultsMeta)> CreateTimesheetAsync(
             Timesheet timesheet)
         {
-            (IList<Timesheet> timesheets, ResultsMeta resultsMeta) = await CreateTimesheetsAsync(new[] { timesheet }).ConfigureAwait(false);
+            (IList<Timesheet> timesheets, ResultsMeta resultsMeta) = await CreateTimesheetsAsync(new[] { timesheet }, default).ConfigureAwait(false);
 
             return (timesheets.FirstOrDefault(), resultsMeta);
         }
@@ -166,9 +118,55 @@ namespace Intuit.TSheets.Api
             Timesheet timesheet,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Timesheet> timesheets, ResultsMeta resultsMeta) = await CreateTimesheetsAsync(new[] { timesheet }, cancellationToken).ConfigureAwait(false);
+
+            return (timesheets.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more timesheets to your company.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Timesheet"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets)
+        {
+            return await CreateTimesheetsAsync(timesheets, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more timesheets to your company.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Timesheet"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<Timesheet>(EndpointName.Timesheets, timesheets);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -236,7 +234,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<Timesheet>, ResultsMeta)> GetTimesheetsAsync(
             TimesheetFilter filter)
         {
-            return await GetTimesheetsAsync(filter, null).ConfigureAwait(false);
+            return await GetTimesheetsAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -260,9 +258,7 @@ namespace Intuit.TSheets.Api
             TimesheetFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetTimesheetsAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -286,11 +282,7 @@ namespace Intuit.TSheets.Api
             TimesheetFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<Timesheet>(EndpointName.Timesheets, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetTimesheetsAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -318,32 +310,16 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<Timesheet>(EndpointName.Timesheets, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
 
         #region Update methods
-
-        /// <summary>
-        /// Update Timesheets.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more timesheets in your company.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Timesheet"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<Timesheet>, ResultsMeta) UpdateTimesheets(IEnumerable<Timesheet> timesheets)
-        {
-            return AsyncUtil.RunSync(() => UpdateTimesheetsAsync(timesheets));
-        }
 
         /// <summary>
         /// Update Timesheets.
@@ -368,7 +344,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Update Timesheets.
+        /// Update Timesheets.
         /// </summary>
         /// <remarks>
         /// Edit one or more timesheets in your company.
@@ -380,39 +356,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Timesheet"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<Timesheet>, ResultsMeta)> UpdateTimesheetsAsync(
-            IEnumerable<Timesheet> timesheets)
+        public (IList<Timesheet>, ResultsMeta) UpdateTimesheets(IEnumerable<Timesheet> timesheets)
         {
-            var context = new UpdateContext<Timesheet>(EndpointName.Timesheets, timesheets);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Update Timesheets, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more timesheets in your company.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Timesheet"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<Timesheet>, ResultsMeta)> UpdateTimesheetsAsync(
-            IEnumerable<Timesheet> timesheets,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => UpdateTimesheetsAsync(timesheets));
         }
 
         /// <summary>
@@ -432,7 +378,7 @@ namespace Intuit.TSheets.Api
             Timesheet timesheet)
         {
             (IList<Timesheet> timesheets, ResultsMeta resultsMeta) =
-                await UpdateTimesheetsAsync(new[] { timesheet }).ConfigureAwait(false);
+                await UpdateTimesheetsAsync(new[] { timesheet }, default).ConfigureAwait(false);
 
             return (timesheets.FirstOrDefault(), resultsMeta);
         }
@@ -457,9 +403,56 @@ namespace Intuit.TSheets.Api
             Timesheet timesheet,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<Timesheet> timesheets, ResultsMeta resultsMeta) =
+                await UpdateTimesheetsAsync(new[] { timesheet }, cancellationToken).ConfigureAwait(false);
+
+            return (timesheets.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more timesheets in your company.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Timesheet"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Timesheet>, ResultsMeta)> UpdateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets)
+        {
+            return await UpdateTimesheetsAsync(timesheets, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more timesheets in your company.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Timesheet"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<Timesheet>, ResultsMeta)> UpdateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets,
+            CancellationToken cancellationToken)
+        {
+            var context = new UpdateContext<Timesheet>(EndpointName.Timesheets, timesheets);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -477,23 +470,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         public void DeleteTimesheet(Timesheet timesheet)
         {
-            DeleteTimesheets(new[] { timesheet });
-        }
-
-        /// <summary>
-        /// Delete Timesheets.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="Timesheet"/> objects.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be deleted.
-        /// </param>
-        public void DeleteTimesheets(IEnumerable<Timesheet> timesheets)
-        {
-            IEnumerable<int> ids = timesheets.Select(j => j.Id);
-
-            DeleteTimesheets(ids);
+            AsyncUtil.RunSync(() => DeleteTimesheetAsync(timesheet));
         }
 
         /// <summary>
@@ -507,7 +484,21 @@ namespace Intuit.TSheets.Api
         /// </param>
         public void DeleteTimesheet(int id)
         {
-            DeleteTimesheets(new[] { id });
+            AsyncUtil.RunSync(() => DeleteTimesheetAsync(id));
+        }
+
+        /// <summary>
+        /// Delete Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Timesheet"/> objects.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be deleted.
+        /// </param>
+        public void DeleteTimesheets(IEnumerable<Timesheet> timesheets)
+        {
+            AsyncUtil.RunSync(() => DeleteTimesheetsAsync(timesheets));
         }
 
         /// <summary>
@@ -537,7 +528,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteTimesheetAsync(
             Timesheet timesheet)
         {
-            await DeleteTimesheetsAsync(new[] { timesheet }).ConfigureAwait(false);
+            await DeleteTimesheetsAsync(new[] { timesheet.Id }, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -557,49 +548,7 @@ namespace Intuit.TSheets.Api
             Timesheet timesheet,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
-        }
-
-        /// <summary>
-        /// Asynchronously Delete Timesheets.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="Timesheet"/> objects.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be deleted.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        public async Task DeleteTimesheetsAsync(
-            IEnumerable<Timesheet> timesheets)
-        {
-            IEnumerable<int> ids = timesheets.Select(t => t.Id);
-
-            await DeleteTimesheetsAsync(ids).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Asynchronously Delete Timesheets, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="Timesheet"/> objects.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be deleted.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        public async Task DeleteTimesheetsAsync(
-            IEnumerable<Timesheet> timesheets,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            await DeleteTimesheetsAsync(new[] { timesheet.Id }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -615,7 +564,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteTimesheetAsync(
             int id)
         {
-            await DeleteTimesheetsAsync(new[] { id }).ConfigureAwait(false);
+            await DeleteTimesheetsAsync(new[] { id }, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -635,9 +584,47 @@ namespace Intuit.TSheets.Api
             int id,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            await DeleteTimesheetsAsync(new[] { id }, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Timesheet"/> objects.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be deleted.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets)
+        {
+            IEnumerable<int> ids = timesheets.Select(t => t.Id);
+
+            await DeleteTimesheetsAsync(ids, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Timesheet"/> objects.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        public async Task DeleteTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets,
+            CancellationToken cancellationToken)
+        {
+            IEnumerable<int> ids = timesheets.Select(t => t.Id);
+
+            await DeleteTimesheetsAsync(ids, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -653,9 +640,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteTimesheetsAsync(
             IEnumerable<int> ids)
         {
-            var context = new DeleteContext<Timesheet>(EndpointName.Timesheets, ids);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
+            await DeleteTimesheetsAsync(ids, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -675,9 +660,9 @@ namespace Intuit.TSheets.Api
             IEnumerable<int> ids,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new DeleteContext<Timesheet>(EndpointName.Timesheets, ids);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_TimesheetsDeleted.cs
+++ b/Intuit.TSheets/Api/DataService_TimesheetsDeleted.cs
@@ -99,7 +99,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<TimesheetsDeleted>, ResultsMeta)> GetTimesheetsDeletedAsync(
             TimesheetsDeletedFilter filter)
         {
-            return await GetTimesheetsDeletedAsync(filter, null).ConfigureAwait(false);
+            return await GetTimesheetsDeletedAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -123,9 +123,7 @@ namespace Intuit.TSheets.Api
             TimesheetsDeletedFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetTimesheetsDeletedAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -149,11 +147,7 @@ namespace Intuit.TSheets.Api
             TimesheetsDeletedFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<TimesheetsDeleted>(EndpointName.TimesheetsDeleted, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetTimesheetsDeletedAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -181,9 +175,11 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<TimesheetsDeleted>(EndpointName.TimesheetsDeleted, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_TimesheetsDeleted.cs
+++ b/Intuit.TSheets/Api/DataService_TimesheetsDeleted.cs
@@ -47,6 +47,26 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="TimesheetsDeletedFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="TimesheetsDeleted"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<TimesheetsDeleted>, ResultsMeta) GetTimesheetsDeleted(
+            TimesheetsDeletedFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetTimesheetsDeletedAsync(filter));
+        }
+
+        /// <summary>
+        /// Retrieve Deleted Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all deleted timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetsDeletedFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -56,9 +76,29 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<TimesheetsDeleted>, ResultsMeta) GetTimesheetsDeleted(
             TimesheetsDeletedFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetTimesheetsDeletedAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Retrieve Deleted Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all deleted timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetsDeletedFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="TimesheetsDeleted"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<TimesheetsDeleted>, ResultsMeta)> GetTimesheetsDeletedAsync(
+            TimesheetsDeletedFilter filter)
+        {
+            return await GetTimesheetsDeletedAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -80,7 +120,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<TimesheetsDeleted>, ResultsMeta)> GetTimesheetsDeletedAsync(
             TimesheetsDeletedFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<TimesheetsDeleted>(EndpointName.TimesheetsDeleted, filter, options);
 

--- a/Intuit.TSheets/Api/DataService_TimesheetsDeleted.cs
+++ b/Intuit.TSheets/Api/DataService_TimesheetsDeleted.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -82,7 +83,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Retrieve Deleted Timesheets.
+        /// Asynchronously Retrieve Deleted Timesheets.
         /// </summary>
         /// <remarks>
         /// Retrieves a list of all deleted timesheets associated with your company,
@@ -102,7 +103,33 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Retrieve Deleted Timesheets.
+        /// Asynchronously Retrieve Deleted Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all deleted timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetsDeletedFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="TimesheetsDeleted"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<TimesheetsDeleted>, ResultsMeta)> GetTimesheetsDeletedAsync(
+            TimesheetsDeletedFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Deleted Timesheets.
         /// </summary>
         /// <remarks>
         /// Retrieves a list of all deleted timesheets associated with your company,
@@ -127,6 +154,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Deleted Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all deleted timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetsDeletedFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="TimesheetsDeleted"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<TimesheetsDeleted>, ResultsMeta)> GetTimesheetsDeletedAsync(
+            TimesheetsDeletedFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Users.cs
+++ b/Intuit.TSheets/Api/DataService_Users.cs
@@ -43,24 +43,6 @@ namespace Intuit.TSheets.Api
         /// Create Users.
         /// </summary>
         /// <remarks>
-        /// Add one or more users to your company.
-        /// </remarks>
-        /// <param name="users">
-        /// The set of <see cref="User"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="User"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<User>, ResultsMeta) CreateUsers(IEnumerable<User> users)
-        {
-            return AsyncUtil.RunSync(() => CreateUsersAsync(users));
-        }
-
-        /// <summary>
-        /// Create Users.
-        /// </summary>
-        /// <remarks>
         /// Add a single user to your company.
         /// </remarks>
         /// <param name="user">
@@ -78,7 +60,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Create Users.
+        /// Create Users.
         /// </summary>
         /// <remarks>
         /// Add one or more users to your company.
@@ -90,39 +72,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="User"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
-            IEnumerable<User> users)
+        public (IList<User>, ResultsMeta) CreateUsers(IEnumerable<User> users)
         {
-            var context = new CreateContext<User>(EndpointName.Users, users);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Create Users, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more users to your company.
-        /// </remarks>
-        /// <param name="users">
-        /// The set of <see cref="User"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="User"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
-            IEnumerable<User> users,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => CreateUsersAsync(users));
         }
 
         /// <summary>
@@ -141,7 +93,7 @@ namespace Intuit.TSheets.Api
         public async Task<(User, ResultsMeta)> CreateUserAsync(
             User user)
         {
-            (IList<User> users, ResultsMeta resultsMeta) = await CreateUsersAsync(new[] { user }).ConfigureAwait(false);
+            (IList<User> users, ResultsMeta resultsMeta) = await CreateUsersAsync(new[] { user }, default).ConfigureAwait(false);
 
             return (users.FirstOrDefault(), resultsMeta);
         }
@@ -166,9 +118,55 @@ namespace Intuit.TSheets.Api
             User user,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<User> users, ResultsMeta resultsMeta) = await CreateUsersAsync(new[] { user }, cancellationToken).ConfigureAwait(false);
+
+            return (users.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Users.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more users to your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
+            IEnumerable<User> users)
+        {
+            return await CreateUsersAsync(users, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more users to your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
+            IEnumerable<User> users,
+            CancellationToken cancellationToken)
+        {
+            var context = new CreateContext<User>(EndpointName.Users, users);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
@@ -268,7 +266,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<User>, ResultsMeta)> GetUsersAsync()
         {
-            return await GetUsersAsync(null, null).ConfigureAwait(false);
+            return await GetUsersAsync(null, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -288,9 +286,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<User>, ResultsMeta)> GetUsersAsync(
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetUsersAsync(null, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -310,7 +306,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<User>, ResultsMeta)> GetUsersAsync(
             RequestOptions options)
         {
-            return await GetUsersAsync(null, options).ConfigureAwait(false);
+            return await GetUsersAsync(null, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -334,9 +330,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetUsersAsync(null, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -356,7 +350,7 @@ namespace Intuit.TSheets.Api
         public async Task<(IList<User>, ResultsMeta)> GetUsersAsync(
             UserFilter filter)
         {
-            return await GetUsersAsync(filter, null).ConfigureAwait(false);
+            return await GetUsersAsync(filter, null, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -380,9 +374,7 @@ namespace Intuit.TSheets.Api
             UserFilter filter,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return await GetUsersAsync(filter, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -406,11 +398,7 @@ namespace Intuit.TSheets.Api
             UserFilter filter,
             RequestOptions options)
         {
-            var context = new GetContext<User>(EndpointName.Users, filter, options);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
+            return await GetUsersAsync(filter, options, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -438,32 +426,16 @@ namespace Intuit.TSheets.Api
             RequestOptions options,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            var context = new GetContext<User>(EndpointName.Users, filter, options);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion
 
         #region Update methods
-
-        /// <summary>
-        /// Update Users.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more users in your company.
-        /// </remarks>
-        /// <param name="users">
-        /// The set of <see cref="User"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="User"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public (IList<User>, ResultsMeta) UpdateUsers(IEnumerable<User> users)
-        {
-            return AsyncUtil.RunSync(() => UpdateUsersAsync(users));
-        }
 
         /// <summary>
         /// Update Users.
@@ -486,7 +458,7 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
-        /// Asynchronously Update Users.
+        /// Update Users.
         /// </summary>
         /// <remarks>
         /// Edit one or more users in your company.
@@ -498,39 +470,9 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="User"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
-            IEnumerable<User> users)
+        public (IList<User>, ResultsMeta) UpdateUsers(IEnumerable<User> users)
         {
-            var context = new UpdateContext<User>(EndpointName.Users, users);
-
-            await ExecuteOperationAsync(context).ConfigureAwait(false);
-
-            return (context.Results.Items, context.ResultsMeta);
-        }
-
-        /// <summary>
-        /// Asynchronously Update Users, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more users in your company.
-        /// </remarks>
-        /// <param name="users">
-        /// The set of <see cref="User"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="User"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        public async Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
-            IEnumerable<User> users,
-            CancellationToken cancellationToken)
-        {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            return AsyncUtil.RunSync(() => UpdateUsersAsync(users));
         }
 
         /// <summary>
@@ -549,7 +491,7 @@ namespace Intuit.TSheets.Api
         public async Task<(User, ResultsMeta)> UpdateUserAsync(
             User user)
         {
-            (IList<User> users, ResultsMeta resultsMeta) = await UpdateUsersAsync(new[] { user }).ConfigureAwait(false);
+            (IList<User> users, ResultsMeta resultsMeta) = await UpdateUsersAsync(new[] { user }, default).ConfigureAwait(false);
 
             return (users.FirstOrDefault(), resultsMeta);
         }
@@ -574,9 +516,55 @@ namespace Intuit.TSheets.Api
             User user,
             CancellationToken cancellationToken)
         {
-            // TODO
-            await Task.Run(() => { });
-            throw new System.NotImplementedException();
+            (IList<User> users, ResultsMeta resultsMeta) = await UpdateUsersAsync(new[] { user }, cancellationToken).ConfigureAwait(false);
+
+            return (users.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Users.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more users in your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
+            IEnumerable<User> users)
+        {
+            return await UpdateUsersAsync(users, default).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more users in your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
+            IEnumerable<User> users,
+            CancellationToken cancellationToken)
+        {
+            var context = new UpdateContext<User>(EndpointName.Users, users);
+
+            await ExecuteOperationAsync(context, cancellationToken).ConfigureAwait(false);
+
+            return (context.Results.Items, context.ResultsMeta);
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Users.cs
+++ b/Intuit.TSheets/Api/DataService_Users.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Core;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -89,13 +90,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="User"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<User>, ResultsMeta)> CreateUsersAsync(IEnumerable<User> users)
+        public async Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
+            IEnumerable<User> users)
         {
             var context = new CreateContext<User>(EndpointName.Users, users);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more users to your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
+            IEnumerable<User> users,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -111,11 +138,37 @@ namespace Intuit.TSheets.Api
         /// The <see cref="User"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(User, ResultsMeta)> CreateUserAsync(User user)
+        public async Task<(User, ResultsMeta)> CreateUserAsync(
+            User user)
         {
             (IList<User> users, ResultsMeta resultsMeta) = await CreateUsersAsync(new[] { user }).ConfigureAwait(false);
 
             return (users.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Create Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single user to your company.
+        /// </remarks>
+        /// <param name="user">
+        /// The <see cref="User"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="User"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(User, ResultsMeta)> CreateUserAsync(
+            User user,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -219,6 +272,28 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Users.
         /// </summary>
         /// <remarks>
@@ -239,6 +314,32 @@ namespace Intuit.TSheets.Api
         }
 
         /// <summary>
+        /// Asynchronously Retrieve Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
         /// Asynchronously Retrieve Users.
         /// </summary>
         /// <remarks>
@@ -256,6 +357,32 @@ namespace Intuit.TSheets.Api
             UserFilter filter)
         {
             return await GetUsersAsync(filter, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="UserFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            UserFilter filter,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -284,6 +411,36 @@ namespace Intuit.TSheets.Api
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="UserFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            UserFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion
@@ -341,13 +498,39 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="User"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(IEnumerable<User> users)
+        public async Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
+            IEnumerable<User> users)
         {
             var context = new UpdateContext<User>(EndpointName.Users, users);
 
             await ExecuteOperationAsync(context).ConfigureAwait(false);
 
             return (context.Results.Items, context.ResultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more users in your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
+            IEnumerable<User> users,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         /// <summary>
@@ -363,11 +546,37 @@ namespace Intuit.TSheets.Api
         /// The <see cref="User"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        public async Task<(User, ResultsMeta)> UpdateUserAsync(User user)
+        public async Task<(User, ResultsMeta)> UpdateUserAsync(
+            User user)
         {
             (IList<User> users, ResultsMeta resultsMeta) = await UpdateUsersAsync(new[] { user }).ConfigureAwait(false);
 
             return (users.FirstOrDefault(), resultsMeta);
+        }
+
+        /// <summary>
+        /// Asynchronously Update Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single user in your company.
+        /// </remarks>
+        /// <param name="user">
+        /// The <see cref="User"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="User"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        public async Task<(User, ResultsMeta)> UpdateUserAsync(
+            User user,
+            CancellationToken cancellationToken)
+        {
+            // TODO
+            await Task.Run(() => { });
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Intuit.TSheets/Api/DataService_Users.cs
+++ b/Intuit.TSheets/Api/DataService_Users.cs
@@ -129,6 +129,22 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all users associated with your company,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<User>, ResultsMeta) GetUsers()
+        {
+            return AsyncUtil.RunSync(() => GetUsersAsync());
+        }
+
+        /// <summary>
+        /// Retrieve Users.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -136,9 +152,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="User"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public (IList<User>, ResultsMeta) GetUsers(RequestOptions options = null)
+        public (IList<User>, ResultsMeta) GetUsers(
+            RequestOptions options)
         {
-            return GetUsers(null, options);
+            return AsyncUtil.RunSync(() => GetUsersAsync(options));
+        }
+
+        /// <summary>
+        /// Retrieve Users.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="UserFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public (IList<User>, ResultsMeta) GetUsers(
+            UserFilter filter)
+        {
+            return AsyncUtil.RunSync(() => GetUsersAsync(filter));
         }
 
         /// <summary>
@@ -160,9 +197,25 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public (IList<User>, ResultsMeta) GetUsers(
             UserFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             return AsyncUtil.RunSync(() => GetUsersAsync(filter, options));
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Users.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<User>, ResultsMeta)> GetUsersAsync()
+        {
+            return await GetUsersAsync(null, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -179,9 +232,30 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="User"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        public async Task<(IList<User>, ResultsMeta)> GetUsersAsync(RequestOptions options = null)
+        public async Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            RequestOptions options)
         {
             return await GetUsersAsync(null, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously Retrieve Users.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="UserFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        public async Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            UserFilter filter)
+        {
+            return await GetUsersAsync(filter, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -203,7 +277,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         public async Task<(IList<User>, ResultsMeta)> GetUsersAsync(
             UserFilter filter,
-            RequestOptions options = null)
+            RequestOptions options)
         {
             var context = new GetContext<User>(EndpointName.Users, filter, options);
 

--- a/Intuit.TSheets/Api/IDataService.cs
+++ b/Intuit.TSheets/Api/IDataService.cs
@@ -7173,7 +7173,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
-        /// Retrieve Deleted Timesheets.
+        /// Asynchronously Retrieve Deleted Timesheets.
         /// </summary>
         /// <remarks>
         /// Retrieves a list of all deleted timesheets associated with your company,
@@ -7190,7 +7190,7 @@ namespace Intuit.TSheets.Api
             TimesheetsDeletedFilter filter);
 
         /// <summary>
-        /// Retrieve Deleted Timesheets, with support for cancellation.
+        /// Asynchronously Retrieve Deleted Timesheets, with support for cancellation.
         /// </summary>
         /// <remarks>
         /// Retrieves a list of all deleted timesheets associated with your company,
@@ -7211,7 +7211,7 @@ namespace Intuit.TSheets.Api
             CancellationToken cancellationToken);
 
         /// <summary>
-        /// Retrieve Deleted Timesheets.
+        /// Asynchronously Retrieve Deleted Timesheets.
         /// </summary>
         /// <remarks>
         /// Retrieves a list of all deleted timesheets associated with your company,
@@ -7232,7 +7232,7 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
-        /// Retrieve Deleted Timesheets, with support for cancellation.
+        /// Asynchronously Retrieve Deleted Timesheets, with support for cancellation.
         /// </summary>
         /// <remarks>
         /// Retrieves a list of all deleted timesheets associated with your company,

--- a/Intuit.TSheets/Api/IDataService.cs
+++ b/Intuit.TSheets/Api/IDataService.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Api
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Model;
     using Intuit.TSheets.Model.Filters;
@@ -79,6 +80,24 @@ namespace Intuit.TSheets.Api
         Task<(User, ResultsMeta)> GetCurrentUserAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve the Current User, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves the user object for the currently authenticated user. This is the
+        /// user that authenticated to TSheets during the OAuth2 authentication process.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param> 
+        /// <returns>
+        /// An instance of the <see cref="User"/> class, representing the current user, along
+        /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
+        /// data.
+        /// </returns>
+        Task<(User, ResultsMeta)> GetCurrentUserAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve the Current User.
         /// </summary>
         /// <remarks>
@@ -95,6 +114,28 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(User, ResultsMeta)> GetCurrentUserAsync(
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve the Current User, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves the user object for the currently authenticated user. This is the
+        /// user that authenticated to TSheets during the OAuth2 authentication process.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param> 
+        /// <returns>
+        /// An instance of the <see cref="User"/> class, representing the current user, along
+        /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
+        /// data.
+        /// </returns>
+        Task<(User, ResultsMeta)> GetCurrentUserAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -182,6 +223,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Fields, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param> 
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Fields.
         /// </summary>
         /// <remarks>
@@ -199,6 +257,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Fields, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param> 
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Fields.
         /// </summary>
         /// <remarks>
@@ -214,6 +293,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
             CustomFieldFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Fields, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param> 
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
+            CustomFieldFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Custom Fields.
@@ -235,6 +335,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
             CustomFieldFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Fields, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
+            CustomFieldFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -269,7 +394,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="CustomFieldItem"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (CustomFieldItem, ResultsMeta) CreateCustomFieldItem(CustomFieldItem customFieldItem);
+        (CustomFieldItem, ResultsMeta) CreateCustomFieldItem(
+            CustomFieldItem customFieldItem);
 
         /// <summary>
         /// Asynchronously Create Custom Field Items.
@@ -288,6 +414,26 @@ namespace Intuit.TSheets.Api
             IEnumerable<CustomFieldItem> customFieldItems);
 
         /// <summary>
+        /// Asynchronously Create Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> CreateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Create Custom Field Items.
         /// </summary>
         /// <remarks>
@@ -304,6 +450,26 @@ namespace Intuit.TSheets.Api
             CustomFieldItem customFieldItem);
 
         /// <summary>
+        /// Asynchronously Create Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single <see cref="CustomFieldItem"/> object to a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItem">
+        /// The <see cref="CustomFieldItem"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="CustomFieldItem"/> object that was created, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(CustomFieldItem, ResultsMeta)> CreateCustomFieldItemAsync(
+            CustomFieldItem customFieldItem,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Retrieve Custom Field Items.
         /// </summary>
         /// <remarks>
@@ -359,6 +525,27 @@ namespace Intuit.TSheets.Api
             Model.Filters.CustomFieldItemFilter filter);
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field items associated with a custom field,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="Model.Filters.CustomFieldItemFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItem>, ResultsMeta)> GetCustomFieldItemsAsync(
+            Model.Filters.CustomFieldItemFilter filter,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Items.
         /// </summary>
         /// <remarks>
@@ -378,6 +565,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<CustomFieldItem>, ResultsMeta)> GetCustomFieldItemsAsync(
             Model.Filters.CustomFieldItemFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field items associated with a custom field,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="Model.Filters.CustomFieldItemFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItem>, ResultsMeta)> GetCustomFieldItemsAsync(
+            Model.Filters.CustomFieldItemFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Update Custom Field Items.
@@ -428,6 +640,26 @@ namespace Intuit.TSheets.Api
             IEnumerable<CustomFieldItem> customFieldItems);
 
         /// <summary>
+        /// Asynchronously Update Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> UpdateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Update Custom Field Items.
         /// </summary>
         /// <remarks>
@@ -442,6 +674,26 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(CustomFieldItem, ResultsMeta)> UpdateCustomFieldItemAsync(
             CustomFieldItem customFieldItem);
+
+        /// <summary>
+        /// Asynchronously Update Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single <see cref="CustomFieldItem"/> object to a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItem">
+        /// The <see cref="CustomFieldItem"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="CustomFieldItem"/> object that was updated, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(CustomFieldItem, ResultsMeta)> UpdateCustomFieldItemAsync(
+            CustomFieldItem customFieldItem,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -529,6 +781,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item Filters.
         /// </summary>
         /// <remarks>
@@ -546,6 +815,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item Filters.
         /// </summary>
         /// <remarks>
@@ -561,6 +851,27 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
             CustomFieldItemFilterFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
+            CustomFieldItemFilterFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Custom Field Item Filters.
@@ -582,6 +893,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
             CustomFieldItemFilterFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
+            CustomFieldItemFilterFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -669,6 +1005,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item Jobcode Filters.
         /// </summary>
         /// <remarks>
@@ -686,6 +1039,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item Jobcode Filters.
         /// </summary>
         /// <remarks>
@@ -701,6 +1075,27 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
             CustomFieldItemJobcodeFilterFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemJobcodeFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
+            CustomFieldItemJobcodeFilterFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Custom Field Item Jobcode Filters.
@@ -722,6 +1117,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
             CustomFieldItemJobcodeFilterFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemJobcodeFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
+            CustomFieldItemJobcodeFilterFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -809,6 +1229,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item User Filters.
         /// </summary>
         /// <remarks>
@@ -826,6 +1263,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Custom Field Item User Filters.
         /// </summary>
         /// <remarks>
@@ -841,6 +1299,27 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
             CustomFieldItemUserFilterFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemUserFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
+            CustomFieldItemUserFilterFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Custom Field Item User Filters.
@@ -862,6 +1341,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
             CustomFieldItemUserFilterFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemUserFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
+            CustomFieldItemUserFilterFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -892,7 +1396,8 @@ namespace Intuit.TSheets.Api
         /// <returns>
         /// An instance of the <see cref="EffectiveSettings"/> class.
         /// </returns> 
-        EffectiveSettings GetEffectiveSettings(EffectiveSettingsFilter filter);
+        EffectiveSettings GetEffectiveSettings(
+            EffectiveSettingsFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Effective Settings.
@@ -907,6 +1412,22 @@ namespace Intuit.TSheets.Api
         Task<EffectiveSettings> GetEffectiveSettingsAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Effective Settings, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all effective settings associated with a single user,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="EffectiveSettings"/> class.
+        /// </returns> 
+        Task<EffectiveSettings> GetEffectiveSettingsAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Effective Settings.
         /// </summary>
         /// <remarks>
@@ -919,7 +1440,28 @@ namespace Intuit.TSheets.Api
         /// <returns>
         /// An instance of the <see cref="EffectiveSettings"/> class.
         /// </returns> 
-        Task<EffectiveSettings> GetEffectiveSettingsAsync(EffectiveSettingsFilter filter);
+        Task<EffectiveSettings> GetEffectiveSettingsAsync(
+            EffectiveSettingsFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Effective Settings, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all effective settings associated with a single user,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="EffectiveSettingsFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="EffectiveSettings"/> class.
+        /// </returns> 
+        Task<EffectiveSettings> GetEffectiveSettingsAsync(
+            EffectiveSettingsFilter filter,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -938,7 +1480,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="File"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<File>, ResultsMeta resultsMeta) UploadFiles(IEnumerable<File> files);
+        (IList<File>, ResultsMeta resultsMeta) UploadFiles(
+            IEnumerable<File> files);
 
         /// <summary>
         /// Upload Files.
@@ -953,7 +1496,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="CustomFieldItem"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (File, ResultsMeta) UploadFile(File file);
+        (File, ResultsMeta) UploadFile(
+            File file);
 
         /// <summary>
         /// Asynchronously Upload Files.
@@ -968,7 +1512,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="File"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<File>, ResultsMeta)> UploadFilesAsync(IEnumerable<File> files);
+        Task<(IList<File>, ResultsMeta)> UploadFilesAsync(
+            IEnumerable<File> files);
+
+        /// <summary>
+        /// Asynchronously Upload Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more <see cref="File"/> objects that can be attached to timesheets.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="File"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<File>, ResultsMeta)> UploadFilesAsync(
+            IEnumerable<File> files,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Upload Files.
@@ -983,7 +1548,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="CustomFieldItem"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(File, ResultsMeta)> UploadFileAsync(File file);
+        Task<(File, ResultsMeta)> UploadFileAsync(
+            File file);
+
+        /// <summary>
+        /// Asynchronously Upload Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single <see cref="File"/> object that can be attached to a timesheet.
+        /// </remarks>
+        /// <param name="file">
+        /// The set of <see cref="File"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="CustomFieldItem"/> object that was created, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(File, ResultsMeta)> UploadFileAsync(
+            File file,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieve Files.
@@ -1067,6 +1653,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<File>, ResultsMeta)> GetFilesAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Files.
         /// </summary>
         /// <remarks>
@@ -1084,6 +1687,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Files.
         /// </summary>
         /// <remarks>
@@ -1099,6 +1723,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<File>, ResultsMeta)> GetFilesAsync(
             FileFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="FileFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            FileFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Files.
@@ -1120,6 +1765,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<File>, ResultsMeta)> GetFilesAsync(
             FileFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="FileFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            FileFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Update Files.
@@ -1165,7 +1835,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="File"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(IEnumerable<File> files);
+        Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
+            IEnumerable<File> files);
+
+        /// <summary>
+        /// Asynchronously Update Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="File"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
+            IEnumerable<File> files,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Files.
@@ -1180,21 +1871,56 @@ namespace Intuit.TSheets.Api
         /// The <see cref="CustomFieldItem"/> object that was updated, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(File, ResultsMeta)> UpdateFileAsync(File file);
+        Task<(File, ResultsMeta)> UpdateFileAsync(
+            File file);
+
+        /// <summary>
+        /// Asynchronously Update Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Update a single <see cref="File"/> object that is/can be attached to a timesheet.
+        /// </remarks>
+        /// <param name="file">
+        /// The set of <see cref="File"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="CustomFieldItem"/> object that was updated, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(File, ResultsMeta)> UpdateFileAsync(
+            File file,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Download the raw bytes of an image file.
         /// </summary>
         /// <param name="id">The id the of the image file to download.</param>
         /// <returns>An array of bytes, representing the image content.</returns>
-        byte[] DownloadFile(int id);
+        byte[] DownloadFile(
+            int id);
 
         /// <summary>
         /// Asynchronously download the raw bytes of an image file.
         /// </summary>
         /// <param name="id">The id the of the image file to download.</param>
         /// <returns>An array of bytes, representing the image content.</returns>
-        Task<byte[]> DownloadFileAsync(int id);
+        Task<byte[]> DownloadFileAsync(
+            int id);
+
+        /// <summary>
+        /// Asynchronously download the raw bytes of an image file, with support for cancellation.
+        /// </summary>
+        /// <param name="id">The id the of the image file to download.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>An array of bytes, representing the image content.</returns>
+        Task<byte[]> DownloadFileAsync(
+            int id,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Delete Files.
@@ -1205,7 +1931,8 @@ namespace Intuit.TSheets.Api
         /// <param name="file">
         /// The <see cref="File"/> object to be deleted.
         /// </param>
-        void DeleteFile(File file);
+        void DeleteFile(
+            File file);
 
         /// <summary>
         /// Delete Files.
@@ -1216,7 +1943,8 @@ namespace Intuit.TSheets.Api
         /// <param name="files">
         /// The set of <see cref="File"/> objects to be deleted.
         /// </param>
-        void DeleteFiles(IEnumerable<File> files);
+        void DeleteFiles(
+            IEnumerable<File> files);
 
         /// <summary>
         /// Delete Files.
@@ -1227,7 +1955,8 @@ namespace Intuit.TSheets.Api
         /// <param name="id">
         /// The id of the <see cref="File"/> object to be deleted.
         /// </param>
-        void DeleteFile(int id);
+        void DeleteFile(
+            int id);
 
         /// <summary>
         /// Delete Files.
@@ -1238,7 +1967,8 @@ namespace Intuit.TSheets.Api
         /// <param name="ids">
         /// The set of ids for the <see cref="File"/> objects to be deleted.
         /// </param>
-        void DeleteFiles(IEnumerable<int> ids);
+        void DeleteFiles(
+            IEnumerable<int> ids);
 
         /// <summary>
         /// Asynchronously Delete Files.
@@ -1250,7 +1980,25 @@ namespace Intuit.TSheets.Api
         /// The <see cref="File"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteFileAsync(File file);
+        Task DeleteFileAsync(
+            File file);
+
+        /// <summary>
+        /// Asynchronously Delete Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="File"/> object.
+        /// </remarks>
+        /// <param name="file">
+        /// The <see cref="File"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteFileAsync(
+            File file,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Files.
@@ -1262,7 +2010,25 @@ namespace Intuit.TSheets.Api
         /// The set of <see cref="File"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteFilesAsync(IEnumerable<File> files);
+        Task DeleteFilesAsync(
+            IEnumerable<File> files);
+
+        /// <summary>
+        /// Asynchronously Delete Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="File"/> objects.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteFilesAsync(
+            IEnumerable<File> files,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Files.
@@ -1274,7 +2040,25 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="File"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteFileAsync(int id);
+        Task DeleteFileAsync(
+            int id);
+
+        /// <summary>
+        /// Asynchronously Delete Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="File"/> object, by id.
+        /// </remarks>
+        /// <param name="id">
+        /// The id of the <see cref="File"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteFileAsync(
+            int id,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Files.
@@ -1286,7 +2070,25 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="File"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteFilesAsync(IEnumerable<int> ids);
+        Task DeleteFilesAsync(
+            IEnumerable<int> ids);
+
+        /// <summary>
+        /// Asynchronously Delete Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="File"/> objects, by id.
+        /// </remarks>
+        /// <param name="ids">
+        /// The set of ids for the <see cref="File"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteFilesAsync(
+            IEnumerable<int> ids,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -1374,6 +2176,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Geofence Configurations.
         /// </summary>
         /// <remarks>
@@ -1391,6 +2210,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Geofence Configurations.
         /// </summary>
         /// <remarks>
@@ -1406,6 +2246,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
             GeofenceConfigFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeofenceConfigFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            GeofenceConfigFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Geofence Configurations.
@@ -1428,6 +2289,31 @@ namespace Intuit.TSheets.Api
             GeofenceConfigFilter filter,
             RequestOptions options);
 
+        /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeofenceConfigFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            GeofenceConfigFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
         #endregion
 
         #region Geolocations
@@ -1442,7 +2328,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Geolocation"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Geolocation>, ResultsMeta) CreateGeolocations(IEnumerable<Geolocation> geolocations);
+        (IList<Geolocation>, ResultsMeta) CreateGeolocations(
+            IEnumerable<Geolocation> geolocations);
 
         /// <summary>
         /// Create Geolocations.
@@ -1454,7 +2341,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Geolocation"/> object that was created, along with as output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Geolocation, ResultsMeta) CreateGeolocation(Geolocation geolocation);
+        (Geolocation, ResultsMeta) CreateGeolocation(
+            Geolocation geolocation);
 
         /// <summary>
         /// Asynchronously Create Geolocations.
@@ -1466,7 +2354,25 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Geolocation"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(IEnumerable<Geolocation> geolocations);
+        Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
+            IEnumerable<Geolocation> geolocations);
+
+        /// <summary>
+        /// Asynchronously Create Geolocations, with support for cancellation.
+        /// </summary>
+        /// <param name="geolocations">
+        /// The set of <see cref="Geolocation"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Geolocation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
+            IEnumerable<Geolocation> geolocations,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Geolocations.
@@ -1478,7 +2384,25 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Geolocation"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Geolocation, ResultsMeta)> CreateGeolocationAsync(Geolocation geolocation);
+        Task<(Geolocation, ResultsMeta)> CreateGeolocationAsync(
+            Geolocation geolocation);
+
+        /// <summary>
+        /// Asynchronously Create Geolocations, with support for cancellation.
+        /// </summary>
+        /// <param name="geolocation">
+        /// The <see cref="Geolocation"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Geolocation"/> object that was created, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Geolocation, ResultsMeta)> CreateGeolocationAsync(
+            Geolocation geolocation,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieve Geolocations.
@@ -1536,6 +2460,27 @@ namespace Intuit.TSheets.Api
             GeolocationFilter filter);
 
         /// <summary>
+        /// Asynchronously Retrieve Geolocations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of geolocations associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeolocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Geolocation"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Geolocation>, ResultsMeta)> GetGeolocationsAsync(
+            GeolocationFilter filter,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Geolocations.
         /// </summary>
         /// <remarks>
@@ -1555,6 +2500,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<Geolocation>, ResultsMeta)> GetGeolocationsAsync(
             GeolocationFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Geolocations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of geolocations associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeolocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Geolocation"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Geolocation>, ResultsMeta)> GetGeolocationsAsync(
+            GeolocationFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -1573,7 +2543,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Group"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Group>, ResultsMeta) CreateGroups(IEnumerable<Group> groups);
+        (IList<Group>, ResultsMeta) CreateGroups(
+            IEnumerable<Group> groups);
 
         /// <summary>
         /// Create Groups.
@@ -1588,7 +2559,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Group"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Group, ResultsMeta) CreateGroup(Group group);
+        (Group, ResultsMeta) CreateGroup(
+            Group group);
 
         /// <summary>
         /// Asynchronously Create Groups.
@@ -1603,7 +2575,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Group"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(IEnumerable<Group> groups);
+        Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
+            IEnumerable<Group> groups);
+
+        /// <summary>
+        /// Asynchronously Create Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more groups to your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
+            IEnumerable<Group> groups,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Groups.
@@ -1618,7 +2611,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Group"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Group, ResultsMeta)> CreateGroupAsync(Group group);
+        Task<(Group, ResultsMeta)> CreateGroupAsync(
+            Group group);
+
+        /// <summary>
+        /// Asynchronously Create Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single group to your company.
+        /// </remarks>
+        /// <param name="group">
+        /// The <see cref="Group"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Group"/> object that was created, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Group, ResultsMeta)> CreateGroupAsync(
+            Group group,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieve Groups.
@@ -1702,6 +2716,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<Group>, ResultsMeta)> GetGroupsAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Groups.
         /// </summary>
         /// <remarks>
@@ -1719,6 +2750,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Groups.
         /// </summary>
         /// <remarks>
@@ -1734,6 +2786,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
             GroupFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GroupFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            GroupFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Groups.
@@ -1757,6 +2830,31 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GroupFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            GroupFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Update Groups.
         /// </summary>
         /// <remarks>
@@ -1769,7 +2867,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Group"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Group>, ResultsMeta) UpdateGroups(IEnumerable<Group> groups);
+        (IList<Group>, ResultsMeta) UpdateGroups(
+            IEnumerable<Group> groups);
 
         /// <summary>
         /// Update Groups.
@@ -1784,7 +2883,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Group"/> object that was updated, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Group, ResultsMeta) UpdateGroup(Group group);
+        (Group, ResultsMeta) UpdateGroup(
+            Group group);
 
         /// <summary>
         /// Asynchronously Update Groups.
@@ -1799,7 +2899,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Group"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(IEnumerable<Group> groups);
+        Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
+            IEnumerable<Group> groups);
+
+        /// <summary>
+        /// Asynchronously Update Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more groups in your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
+            IEnumerable<Group> groups,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Groups.
@@ -1814,7 +2935,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Group"/> object that was updated, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Group, ResultsMeta)> UpdateGroupAsync(Group group);
+        Task<(Group, ResultsMeta)> UpdateGroupAsync(
+            Group group);
+
+        /// <summary>
+        /// Asynchronously Update Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single group in your company.
+        /// </remarks>
+        /// <param name="group">
+        /// The <see cref="Group"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Group"/> object that was updated, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Group, ResultsMeta)> UpdateGroupAsync(
+            Group group,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -1833,7 +2975,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Invitation"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Invitation>, ResultsMeta) CreateInvitations(IEnumerable<Invitation> invitations);
+        (IList<Invitation>, ResultsMeta) CreateInvitations(
+            IEnumerable<Invitation> invitations);
 
         /// <summary>
         /// Create Invitations.
@@ -1848,7 +2991,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Invitation"/> object that was created, along with as output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Invitation, ResultsMeta) CreateInvitation(Invitation invitation);
+        (Invitation, ResultsMeta) CreateInvitation(
+            Invitation invitation);
 
         /// <summary>
         /// Asynchronously Create Invitations.
@@ -1863,10 +3007,31 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Invitation"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(IEnumerable<Invitation> invitations);
+        Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
+            IEnumerable<Invitation> invitations);
 
         /// <summary>
-        /// Asynchronously Create Invitations.
+        /// Asynchronously Create Invitations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Invite one or more users to your company.
+        /// </remarks>
+        /// <param name="invitations">
+        /// The set of <see cref="Invitation"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Invitation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
+            IEnumerable<Invitation> invitations,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create An Invitation.
         /// </summary>
         /// <remarks>
         /// Invite a single user to your company.
@@ -1878,7 +3043,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Invitation"/> object that was created, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Invitation, ResultsMeta)> CreateInvitationAsync(Invitation invitation);
+        Task<(Invitation, ResultsMeta)> CreateInvitationAsync(
+            Invitation invitation);
+
+        /// <summary>
+        /// Asynchronously Create An Invitation, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Invite a single user to your company.
+        /// </remarks>
+        /// <param name="invitation">
+        /// The <see cref="Invitation"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Invitation"/> object that was created, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Invitation, ResultsMeta)> CreateInvitationAsync(
+            Invitation invitation,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -1897,7 +3083,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Jobcode"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Jobcode>, ResultsMeta) CreateJobcodes(IEnumerable<Jobcode> jobcodes);
+        (IList<Jobcode>, ResultsMeta) CreateJobcodes(
+            IEnumerable<Jobcode> jobcodes);
 
         /// <summary>
         /// Create Jobcodes.
@@ -1912,7 +3099,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Jobcode"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Jobcode, ResultsMeta) CreateJobcode(Jobcode jobcode);
+        (Jobcode, ResultsMeta) CreateJobcode(
+            Jobcode jobcode);
 
         /// <summary>
         /// Asynchronously Create Jobcodes.
@@ -1927,10 +3115,31 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Jobcode"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(IEnumerable<Jobcode> jobcodes);
+        Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes);
 
         /// <summary>
-        /// Asynchronously Create Jobcodes.
+        /// Asynchronously Create Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcodes to your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Jobcode"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create A Jobcode.
         /// </summary>
         /// <remarks>
         /// Add a single jobcode to your company.
@@ -1942,7 +3151,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Jobcode"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Jobcode, ResultsMeta)> CreateJobcodeAsync(Jobcode jobcode);
+        Task<(Jobcode, ResultsMeta)> CreateJobcodeAsync(
+            Jobcode jobcode);
+
+        /// <summary>
+        /// Asynchronously Create A Jobcode, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single jobcode to your company.
+        /// </remarks>
+        /// <param name="jobcode">
+        /// The <see cref="Jobcode"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Jobcode"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Jobcode, ResultsMeta)> CreateJobcodeAsync(
+            Jobcode jobcode,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieve Jobcodes.
@@ -2026,6 +3256,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Jobcodes.
         /// </summary>
         /// <remarks>
@@ -2043,6 +3290,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Jobcodes.
         /// </summary>
         /// <remarks>
@@ -2058,6 +3326,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
             JobcodeFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            JobcodeFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Jobcodes.
@@ -2079,6 +3368,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
             JobcodeFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            JobcodeFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Update Jobcodes.
@@ -2109,7 +3423,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Jobcode"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Jobcode, ResultsMeta) UpdateJobcode(Jobcode jobcode);
+        (Jobcode, ResultsMeta) UpdateJobcode(
+            Jobcode jobcode);
 
         /// <summary>
         /// Asynchronously Update Jobcodes.
@@ -2124,7 +3439,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Jobcode"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(IEnumerable<Jobcode> jobcodes);
+        Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes);
+
+        /// <summary>
+        /// Asynchronously Update Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more jobcodes in your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Jobcode"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Jobcodes.
@@ -2139,7 +3475,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Jobcode"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Jobcode, ResultsMeta)> UpdateJobcodeAsync(Jobcode jobcode);
+        Task<(Jobcode, ResultsMeta)> UpdateJobcodeAsync(
+            Jobcode jobcode);
+
+        /// <summary>
+        /// Asynchronously Update Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single jobcode in your company.
+        /// </remarks>
+        /// <param name="jobcode">
+        /// The <see cref="Jobcode"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Jobcode"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Jobcode, ResultsMeta)> UpdateJobcodeAsync(
+            Jobcode jobcode,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -2158,7 +3515,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<JobcodeAssignment>, ResultsMeta) CreateJobcodeAssignments(IEnumerable<JobcodeAssignment> jobcodeAssignments);
+        (IList<JobcodeAssignment>, ResultsMeta) CreateJobcodeAssignments(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments);
 
         /// <summary>
         /// Create Jobcode Assignments.
@@ -2173,7 +3531,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="JobcodeAssignment"/> assignment that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (JobcodeAssignment, ResultsMeta) CreateJobcodeAssignment(JobcodeAssignment jobcodeAssignment);
+        (JobcodeAssignment, ResultsMeta) CreateJobcodeAssignment(
+            JobcodeAssignment jobcodeAssignment);
 
         /// <summary>
         /// Asynchronously Create Jobcode Assignments.
@@ -2188,7 +3547,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(IEnumerable<JobcodeAssignment> jobcodeAssignments);
+        Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments);
+
+        /// <summary>
+        /// Asynchronously Create Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcode assignments to a user.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignments to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Jobcode Assignments.
@@ -2203,7 +3583,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="JobcodeAssignment"/> assignment that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(JobcodeAssignment, ResultsMeta)> CreateJobcodeAssignmentAsync(JobcodeAssignment jobcodeAssignment);
+        Task<(JobcodeAssignment, ResultsMeta)> CreateJobcodeAssignmentAsync(
+            JobcodeAssignment jobcodeAssignment);
+
+        /// <summary>
+        /// Asynchronously Create Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single jobcode assignment to a user.
+        /// </remarks>
+        /// <param name="jobcodeAssignment">
+        /// The <see cref="JobcodeAssignment"/> assignment to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="JobcodeAssignment"/> assignment that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(JobcodeAssignment, ResultsMeta)> CreateJobcodeAssignmentAsync(
+            JobcodeAssignment jobcodeAssignment,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieve Jobcode Assignments.
@@ -2287,6 +3688,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Jobcode Assignments.
         /// </summary>
         /// <remarks>
@@ -2304,6 +3722,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Jobcode Assignments.
         /// </summary>
         /// <remarks>
@@ -2319,6 +3758,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
             JobcodeAssignmentFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeAssignmentFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            JobcodeAssignmentFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Jobcode Assignments.
@@ -2342,6 +3802,31 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeAssignmentFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            JobcodeAssignmentFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Delete Jobcode Assignments.
         /// </summary>
         /// <remarks>
@@ -2350,7 +3835,8 @@ namespace Intuit.TSheets.Api
         /// <param name="jobcodeAssignment">
         /// The <see cref="JobcodeAssignment"/> assignment object to be deleted.
         /// </param>
-        void DeleteJobcodeAssignment(JobcodeAssignment jobcodeAssignment);
+        void DeleteJobcodeAssignment(
+            JobcodeAssignment jobcodeAssignment);
 
         /// <summary>
         /// Delete Jobcode Assignments.
@@ -2373,7 +3859,8 @@ namespace Intuit.TSheets.Api
         /// <param name="id">
         /// The id of the <see cref="JobcodeAssignment"/> assignment object to be deleted.
         /// </param>
-        void DeleteJobcodeAssignment(int id);
+        void DeleteJobcodeAssignment(
+            int id);
 
         /// <summary>
         /// Delete Jobcode Assignments.
@@ -2384,7 +3871,8 @@ namespace Intuit.TSheets.Api
         /// <param name="ids">
         /// The set of ids for the <see cref="JobcodeAssignment"/> assignment objects to be deleted.
         /// </param>
-        void DeleteJobcodeAssignments(IEnumerable<int> ids);
+        void DeleteJobcodeAssignments(
+            IEnumerable<int> ids);
 
         /// <summary>
         /// Asynchronously Delete Jobcode Assignments.
@@ -2396,7 +3884,25 @@ namespace Intuit.TSheets.Api
         /// The <see cref="JobcodeAssignment"/> assignment object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteJobcodeAssignmentAsync(JobcodeAssignment jobcodeAssignment);
+        Task DeleteJobcodeAssignmentAsync(
+            JobcodeAssignment jobcodeAssignment);
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="JobcodeAssignment"/> assignment.
+        /// </remarks>
+        /// <param name="jobcodeAssignment">
+        /// The <see cref="JobcodeAssignment"/> assignment object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteJobcodeAssignmentAsync(
+            JobcodeAssignment jobcodeAssignment,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Jobcode Assignments.
@@ -2408,7 +3914,25 @@ namespace Intuit.TSheets.Api
         /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteJobcodeAssignmentsAsync(IEnumerable<JobcodeAssignment> jobcodeAssignments);
+        Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments);
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Jobcode Assignments.
@@ -2420,7 +3944,25 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="JobcodeAssignment"/> assignment object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteJobcodeAssignmentAsync(int id);
+        Task DeleteJobcodeAssignmentAsync(
+            int id);
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="JobcodeAssignment"/> assignment, by id.
+        /// </remarks>
+        /// <param name="id">
+        /// The id of the <see cref="JobcodeAssignment"/> assignment object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteJobcodeAssignmentAsync(
+            int id,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Jobcode Assignments.
@@ -2432,7 +3974,25 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="JobcodeAssignment"/> assignment objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteJobcodeAssignmentsAsync(IEnumerable<int> ids);
+        Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<int> ids);
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="JobcodeAssignment"/> assignments, by id.
+        /// </remarks>
+        /// <param name="ids">
+        /// The set of ids for the <see cref="JobcodeAssignment"/> assignment objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<int> ids,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -2461,7 +4021,8 @@ namespace Intuit.TSheets.Api
         /// <returns>
         /// An instance of a <see cref="LastModifiedTimestamps"/> class.
         /// </returns>
-        LastModifiedTimestamps GetLastModifiedTimestamps(LastModifiedTimestampsFilter filter);
+        LastModifiedTimestamps GetLastModifiedTimestamps(
+            LastModifiedTimestampsFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Last Modified Timestamps.
@@ -2475,6 +4036,21 @@ namespace Intuit.TSheets.Api
         Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Last Modified Timestamps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of last modified timestamps associated with each requested API endpoint. 
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of a <see cref="LastModifiedTimestamps"/> class.
+        /// </returns>
+        Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Last Modified Timestamps.
         /// </summary>
         /// <remarks>
@@ -2486,7 +4062,27 @@ namespace Intuit.TSheets.Api
         /// <returns>
         /// An instance of a <see cref="LastModifiedTimestamps"/> class.
         /// </returns>
-        Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync(LastModifiedTimestampsFilter filter);
+        Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync(
+            LastModifiedTimestampsFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Last Modified Timestamps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of last modified timestamps associated with each requested API endpoint. 
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LastModifiedTimestampsFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of a <see cref="LastModifiedTimestamps"/> class.
+        /// </returns>
+        Task<LastModifiedTimestamps> GetLastModifiedTimestampsAsync(
+            LastModifiedTimestampsFilter filter,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -2505,7 +4101,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Location"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Location>, ResultsMeta) CreateLocations(IEnumerable<Location> locations);
+        (IList<Location>, ResultsMeta) CreateLocations(
+            IEnumerable<Location> locations);
 
         /// <summary>
         /// Create Locations.
@@ -2520,7 +4117,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Location"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Location, ResultsMeta) CreateLocation(Location location);
+        (Location, ResultsMeta) CreateLocation(
+            Location location);
 
         /// <summary>
         /// Asynchronously Create Locations.
@@ -2535,7 +4133,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Location"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(IEnumerable<Location> locations);
+        Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
+            IEnumerable<Location> locations);
+
+        /// <summary>
+        /// Asynchronously Create Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more locations to your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
+            IEnumerable<Location> locations,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Locations.
@@ -2550,7 +4169,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Location"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Location, ResultsMeta)> CreateLocationAsync(Location location);
+        Task<(Location, ResultsMeta)> CreateLocationAsync(
+            Location location);
+
+        /// <summary>
+        /// Asynchronously Create Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single location to your company.
+        /// </remarks>
+        /// <param name="location">
+        /// The <see cref="Location"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Location"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Location, ResultsMeta)> CreateLocationAsync(
+            Location location,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieve Locations.
@@ -2634,6 +4274,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<Location>, ResultsMeta)> GetLocationsAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Locations.
         /// </summary>
         /// <remarks>
@@ -2651,6 +4308,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Locations.
         /// </summary>
         /// <remarks>
@@ -2666,6 +4344,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
             LocationFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            LocationFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Locations.
@@ -2689,6 +4388,31 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            LocationFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Update Locations.
         /// </summary>
         /// <remarks>
@@ -2701,7 +4425,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Location"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Location>, ResultsMeta) UpdateLocations(IEnumerable<Location> locations);
+        (IList<Location>, ResultsMeta) UpdateLocations(
+            IEnumerable<Location> locations);
 
         /// <summary>
         /// Update Locations.
@@ -2716,7 +4441,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Location"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Location, ResultsMeta) UpdateLocation(Location location);
+        (Location, ResultsMeta) UpdateLocation(
+            Location location);
 
         /// <summary>
         /// Asynchronously Update Locations.
@@ -2731,7 +4457,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Location"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(IEnumerable<Location> locations);
+        Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
+            IEnumerable<Location> locations);
+
+        /// <summary>
+        /// Asynchronously Update Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more locations in your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
+            IEnumerable<Location> locations,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Locations.
@@ -2746,7 +4493,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Location"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Location, ResultsMeta)> UpdateLocationAsync(Location location);
+        Task<(Location, ResultsMeta)> UpdateLocationAsync(
+            Location location);
+
+        /// <summary>
+        /// Asynchronously Update Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single location in your company.
+        /// </remarks>
+        /// <param name="location">
+        /// The <see cref="Location"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Location"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Location, ResultsMeta)> UpdateLocationAsync(
+            Location location,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -2834,6 +4602,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve LocationsMaps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve LocationsMaps.
         /// </summary>
         /// <remarks>
@@ -2851,6 +4636,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve LocationsMaps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve LocationsMaps.
         /// </summary>
         /// <remarks>
@@ -2866,6 +4672,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
             LocationsMapFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve LocationsMaps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            LocationsMapFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve LocationsMaps.
@@ -2887,6 +4714,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
             LocationsMapFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve LocationsMaps, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            LocationsMapFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -2974,6 +4826,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Managed Clients, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Managed Clients.
         /// </summary>
         /// <remarks>
@@ -2991,6 +4860,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Managed Clients, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Managed Clients.
         /// </summary>
         /// <remarks>
@@ -3006,6 +4896,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
             ManagedClientFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Managed Clients, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ManagedClientFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            ManagedClientFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Managed Clients.
@@ -3028,6 +4939,31 @@ namespace Intuit.TSheets.Api
             ManagedClientFilter filter,
             RequestOptions options);
 
+        /// <summary>
+        /// Asynchronously Retrieve Managed Clients, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ManagedClientFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            ManagedClientFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
         #endregion
 
         #region Notifications
@@ -3045,7 +4981,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Notification"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Notification>, ResultsMeta) CreateNotifications(IEnumerable<Notification> notifications);
+        (IList<Notification>, ResultsMeta) CreateNotifications(
+            IEnumerable<Notification> notifications);
 
         /// <summary>
         /// Create Notifications.
@@ -3060,7 +4997,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Notification"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Notification, ResultsMeta) CreateNotification(Notification notification);
+        (Notification, ResultsMeta) CreateNotification(
+            Notification notification);
 
         /// <summary>
         /// Asynchronously Create Notifications.
@@ -3075,7 +5013,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Notification"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(IEnumerable<Notification> notifications);
+        Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
+            IEnumerable<Notification> notifications);
+
+        /// <summary>
+        /// Asynchronously Create Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more notifications.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Notification"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
+            IEnumerable<Notification> notifications,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Notifications.
@@ -3090,7 +5049,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Notification"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Notification, ResultsMeta)> CreateNotificationAsync(Notification notification);
+        Task<(Notification, ResultsMeta)> CreateNotificationAsync(
+            Notification notification);
+
+        /// <summary>
+        /// Asynchronously Create Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single notification.
+        /// </remarks>
+        /// <param name="notification">
+        /// The <see cref="Notification"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Notification"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Notification, ResultsMeta)> CreateNotificationAsync(
+            Notification notification,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieve Notifications.
@@ -3173,6 +5153,24 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync();
 
+
+        /// <summary>
+        /// Asynchronously Retrieve Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            CancellationToken cancellationToken);
+
         /// <summary>
         /// Asynchronously Retrieve Notifications.
         /// </summary>
@@ -3191,6 +5189,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Notifications.
         /// </summary>
         /// <remarks>
@@ -3206,6 +5225,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
             NotificationFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="NotificationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            NotificationFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Notifications.
@@ -3229,6 +5269,31 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="NotificationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            NotificationFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Delete Notifications.
         /// </summary>
         /// <remarks>
@@ -3237,7 +5302,8 @@ namespace Intuit.TSheets.Api
         /// <param name="notification">
         /// The <see cref="Notification"/> object to be deleted.
         /// </param>
-        void DeleteNotification(Notification notification);
+        void DeleteNotification(
+            Notification notification);
 
         /// <summary>
         /// Delete Notifications.
@@ -3248,7 +5314,8 @@ namespace Intuit.TSheets.Api
         /// <param name="notifications">
         /// The set of <see cref="Notification"/> objects to be deleted.
         /// </param>
-        void DeleteNotifications(IEnumerable<Notification> notifications);
+        void DeleteNotifications(
+            IEnumerable<Notification> notifications);
 
         /// <summary>
         /// Delete Notifications.
@@ -3259,7 +5326,8 @@ namespace Intuit.TSheets.Api
         /// <param name="id">
         /// The id of the <see cref="Notification"/> object to be deleted.
         /// </param>
-        void DeleteNotification(int id);
+        void DeleteNotification(
+            int id);
 
         /// <summary>
         /// Delete Notifications.
@@ -3270,7 +5338,8 @@ namespace Intuit.TSheets.Api
         /// <param name="ids">
         /// The set of ids for the <see cref="Notification"/> objects to be deleted.
         /// </param>
-        void DeleteNotifications(IEnumerable<int> ids);
+        void DeleteNotifications(
+            IEnumerable<int> ids);
 
         /// <summary>
         /// Asynchronously Delete Notifications.
@@ -3282,7 +5351,25 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Notification"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteNotificationAsync(Notification notification);
+        Task DeleteNotificationAsync(
+            Notification notification);
+
+        /// <summary>
+        /// Asynchronously Delete Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="Notification"/> object.
+        /// </remarks>
+        /// <param name="notification">
+        /// The <see cref="Notification"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteNotificationAsync(
+            Notification notification,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Notifications.
@@ -3294,7 +5381,25 @@ namespace Intuit.TSheets.Api
         /// The set of <see cref="Notification"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteNotificationsAsync(IEnumerable<Notification> notifications);
+        Task DeleteNotificationsAsync(
+            IEnumerable<Notification> notifications);
+
+        /// <summary>
+        /// Asynchronously Delete Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Notification"/> objects.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteNotificationsAsync(
+            IEnumerable<Notification> notifications,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Notifications.
@@ -3306,7 +5411,25 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="Notification"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteNotificationAsync(int id);
+        Task DeleteNotificationAsync(
+            int id);
+
+        /// <summary>
+        /// Asynchronously Delete Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="Notification"/> object, by id.
+        /// </remarks>
+        /// <param name="id">
+        /// The id of the <see cref="Notification"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteNotificationAsync(
+            int id,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Notifications.
@@ -3318,7 +5441,25 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="Notification"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteNotificationsAsync(IEnumerable<int> ids);
+        Task DeleteNotificationsAsync(
+            IEnumerable<int> ids);
+
+        /// <summary>
+        /// Asynchronously Delete Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Notification"/> objects, by id.
+        /// </remarks>
+        /// <param name="ids">
+        /// The set of ids for the <see cref="Notification"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteNotificationsAsync(
+            IEnumerable<int> ids,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -3337,7 +5478,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Reminder"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Reminder>, ResultsMeta) CreateReminders(IEnumerable<Reminder> reminders);
+        (IList<Reminder>, ResultsMeta) CreateReminders(
+            IEnumerable<Reminder> reminders);
 
         /// <summary>
         /// Create Reminders.
@@ -3352,7 +5494,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Reminder"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Reminder, ResultsMeta) CreateReminder(Reminder reminder);
+        (Reminder, ResultsMeta) CreateReminder(
+            Reminder reminder);
 
         /// <summary>
         /// Asynchronously Create Reminders.
@@ -3367,7 +5510,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Reminder"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(IEnumerable<Reminder> reminders);
+        Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
+            IEnumerable<Reminder> reminders);
+
+        /// <summary>
+        /// Asynchronously Create Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more user-specific or company-wide reminders.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
+            IEnumerable<Reminder> reminders,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Reminders.
@@ -3382,7 +5546,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Reminder"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Reminder, ResultsMeta)> CreateReminderAsync(Reminder reminder);
+        Task<(Reminder, ResultsMeta)> CreateReminderAsync(
+            Reminder reminder);
+
+        /// <summary>
+        /// Asynchronously Create Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single user-specific or company-wide reminder.
+        /// </remarks>
+        /// <param name="reminder">
+        /// The <see cref="Reminder"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Reminder"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Reminder, ResultsMeta)> CreateReminderAsync(
+            Reminder reminder,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieve Reminders.
@@ -3440,6 +5625,27 @@ namespace Intuit.TSheets.Api
             ReminderFilter filter);
 
         /// <summary>
+        /// Asynchronously Retrieve Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all reminders associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ReminderFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Reminder"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Reminder>, ResultsMeta)> GetRemindersAsync(
+            ReminderFilter filter,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Reminders.
         /// </summary>
         /// <remarks>
@@ -3459,6 +5665,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<Reminder>, ResultsMeta)> GetRemindersAsync(
             ReminderFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all reminders associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ReminderFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Reminder"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Reminder>, ResultsMeta)> GetRemindersAsync(
+            ReminderFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Update Reminders.
@@ -3473,7 +5704,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Reminder"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Reminder>, ResultsMeta) UpdateReminders(IEnumerable<Reminder> reminders);
+        (IList<Reminder>, ResultsMeta) UpdateReminders(
+            IEnumerable<Reminder> reminders);
 
         /// <summary>
         /// Update Reminders.
@@ -3488,7 +5720,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Reminder"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Reminder, ResultsMeta) UpdateReminder(Reminder reminder);
+        (Reminder, ResultsMeta) UpdateReminder(
+            Reminder reminder);
 
         /// <summary>
         /// Asynchronously Update Reminders.
@@ -3507,6 +5740,26 @@ namespace Intuit.TSheets.Api
             IEnumerable<Reminder> reminders);
 
         /// <summary>
+        /// Asynchronously Update Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more reminders for employees within your company.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Reminder>, ResultsMeta)> UpdateRemindersAsync(
+            IEnumerable<Reminder> reminders,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Update Reminders.
         /// </summary>
         /// <remarks>
@@ -3519,7 +5772,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Reminder"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Reminder, ResultsMeta)> UpdateReminderAsync(Reminder reminder);
+        Task<(Reminder, ResultsMeta)> UpdateReminderAsync(
+            Reminder reminder);
+
+        /// <summary>
+        /// Asynchronously Update Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single reminder for employees within your company.
+        /// </remarks>
+        /// <param name="reminder">
+        /// The <see cref="Reminder"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Reminder"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Reminder, ResultsMeta)> UpdateReminderAsync(
+            Reminder reminder,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -3552,7 +5826,8 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="CurrentTotalsReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (CurrentTotalsReport, ResultsMeta) GetCurrentTotalsReport(CurrentTotalsReportFilter filter);
+        (CurrentTotalsReport, ResultsMeta) GetCurrentTotalsReport(
+            CurrentTotalsReportFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Current Totals Report.
@@ -3568,6 +5843,23 @@ namespace Intuit.TSheets.Api
         Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Current Totals Report, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a snapshot report for the current totals (shift and day) along with additional
+        /// information provided for those who are currently on the clock.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="CurrentTotalsReport"/> class, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Current Totals Report.
         /// </summary>
         /// <remarks>
@@ -3581,7 +5873,29 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="CurrentTotalsReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync(CurrentTotalsReportFilter filter);
+        Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync(
+            CurrentTotalsReportFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Current Totals Report, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a snapshot report for the current totals (shift and day) along with additional
+        /// information provided for those who are currently on the clock.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CurrentTotalsReportFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="CurrentTotalsReport"/> class, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(CurrentTotalsReport, ResultsMeta)> GetCurrentTotalsReportAsync(
+            CurrentTotalsReportFilter filter,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -3601,7 +5915,8 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="PayrollReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (PayrollReport, ResultsMeta) GetPayrollReport(PayrollReportFilter filter);
+        (PayrollReport, ResultsMeta) GetPayrollReport(
+            PayrollReportFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Payroll Report.
@@ -3617,7 +5932,29 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="PayrollReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(PayrollReport, ResultsMeta)> GetPayrollReportAsync(PayrollReportFilter filter);
+        Task<(PayrollReport, ResultsMeta)> GetPayrollReportAsync(
+            PayrollReportFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Payroll Report, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a payroll report associated with a time frame,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="PayrollReportFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="PayrollReport"/> class, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(PayrollReport, ResultsMeta)> GetPayrollReportAsync(
+            PayrollReportFilter filter,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -3636,7 +5973,8 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="PayrollByJobcodeReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (PayrollByJobcodeReport, ResultsMeta) GetPayrollByJobcodeReport(PayrollByJobcodeReportFilter filter);
+        (PayrollByJobcodeReport, ResultsMeta) GetPayrollByJobcodeReport(
+            PayrollByJobcodeReportFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Payroll by Jobcode Report.
@@ -3652,7 +5990,29 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="PayrollByJobcodeReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(PayrollByJobcodeReport, ResultsMeta)> GetPayrollByJobcodeReportAsync(PayrollByJobcodeReportFilter filter);
+        Task<(PayrollByJobcodeReport, ResultsMeta)> GetPayrollByJobcodeReportAsync(
+            PayrollByJobcodeReportFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Payroll by Jobcode Report, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a payroll report, broken down by jobcode,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="PayrollByJobcodeReportFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="PayrollByJobcodeReport"/> class, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(PayrollByJobcodeReport, ResultsMeta)> GetPayrollByJobcodeReportAsync(
+            PayrollByJobcodeReportFilter filter,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -3671,7 +6031,8 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="ProjectReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (ProjectReport, ResultsMeta) GetProjectReport(ProjectReportFilter filter);
+        (ProjectReport, ResultsMeta) GetProjectReport(
+            ProjectReportFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Project Report.
@@ -3686,7 +6047,28 @@ namespace Intuit.TSheets.Api
         /// An instance of the <see cref="ProjectReport"/> class, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(ProjectReport, ResultsMeta)> GetProjectReportAsync(ProjectReportFilter filter);
+        Task<(ProjectReport, ResultsMeta)> GetProjectReportAsync(
+            ProjectReportFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Project Report, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a project report with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ProjectReportFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An instance of the <see cref="ProjectReport"/> class, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(ProjectReport, ResultsMeta)> GetProjectReportAsync(
+            ProjectReportFilter filter,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -3774,6 +6156,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Schedule Calendars.
         /// </summary>
         /// <remarks>
@@ -3791,6 +6190,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Schedule Calendars.
         /// </summary>
         /// <remarks>
@@ -3806,6 +6226,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
             ScheduleCalendarFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleCalendarFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            ScheduleCalendarFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Schedule Calendars.
@@ -3828,6 +6269,31 @@ namespace Intuit.TSheets.Api
             ScheduleCalendarFilter filter,
             RequestOptions options);
 
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleCalendarFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            ScheduleCalendarFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
         #endregion
 
         #region ScheduleEvents
@@ -3845,7 +6311,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<ScheduleEvent>, ResultsMeta) CreateScheduleEvents(IEnumerable<ScheduleEvent> scheduleEvents);
+        (IList<ScheduleEvent>, ResultsMeta) CreateScheduleEvents(
+            IEnumerable<ScheduleEvent> scheduleEvents);
 
         /// <summary>
         /// Create ScheduleEvents.
@@ -3860,7 +6327,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="ScheduleEvent"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (ScheduleEvent, ResultsMeta) CreateScheduleEvent(ScheduleEvent scheduleEvent);
+        (ScheduleEvent, ResultsMeta) CreateScheduleEvent(
+            ScheduleEvent scheduleEvent);
 
         /// <summary>
         /// Asynchronously Create Schedule Events.
@@ -3875,7 +6343,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(IEnumerable<ScheduleEvent> scheduleEvents);
+        Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents);
+
+        /// <summary>
+        /// Asynchronously Create Schedule Events, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create ScheduleEvents.
@@ -3890,7 +6379,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="ScheduleEvent"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(ScheduleEvent, ResultsMeta)> CreateScheduleEventAsync(ScheduleEvent scheduleEvent);
+        Task<(ScheduleEvent, ResultsMeta)> CreateScheduleEventAsync(
+            ScheduleEvent scheduleEvent);
+
+        /// <summary>
+        /// Asynchronously Create ScheduleEvents, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single schedule event.
+        /// </remarks>
+        /// <param name="scheduleEvent">
+        /// The <see cref="ScheduleEvent"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ScheduleEvent"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(ScheduleEvent, ResultsMeta)> CreateScheduleEventAsync(
+            ScheduleEvent scheduleEvent,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieve Schedule Events.
@@ -3948,6 +6458,27 @@ namespace Intuit.TSheets.Api
             ScheduleEventFilter filter);
 
         /// <summary>
+        /// Asynchronously Retrieve Schedule Events, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule events associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleEventFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleEvent"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ScheduleEvent>, ResultsMeta)> GetScheduleEventsAsync(
+            ScheduleEventFilter filter,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Schedule Events.
         /// </summary>
         /// <remarks>
@@ -3967,6 +6498,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<ScheduleEvent>, ResultsMeta)> GetScheduleEventsAsync(
             ScheduleEventFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Events, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule events associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleEventFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleEvent"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ScheduleEvent>, ResultsMeta)> GetScheduleEventsAsync(
+            ScheduleEventFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Update Schedule Events.
@@ -3981,7 +6537,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<ScheduleEvent>, ResultsMeta) UpdateScheduleEvents(IEnumerable<ScheduleEvent> scheduleEvents);
+        (IList<ScheduleEvent>, ResultsMeta) UpdateScheduleEvents(
+            IEnumerable<ScheduleEvent> scheduleEvents);
 
         /// <summary>
         /// Update ScheduleEvents.
@@ -4016,6 +6573,26 @@ namespace Intuit.TSheets.Api
             IEnumerable<ScheduleEvent> scheduleEvents);
 
         /// <summary>
+        /// Asynchronously Update ScheduleEvents, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<ScheduleEvent>, ResultsMeta)> UpdateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Update ScheduleEvents.
         /// </summary>
         /// <remarks>
@@ -4030,6 +6607,26 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(ScheduleEvent, ResultsMeta)> UpdateScheduleEventAsync(
             ScheduleEvent scheduleEvent);
+
+        /// <summary>
+        /// Asynchronously Update ScheduleEvents, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single schedule event.
+        /// </remarks>
+        /// <param name="scheduleEvent">
+        /// The <see cref="ScheduleEvent"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ScheduleEvent"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(ScheduleEvent, ResultsMeta)> UpdateScheduleEventAsync(
+            ScheduleEvent scheduleEvent,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -4048,7 +6645,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Timesheet"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Timesheet>, ResultsMeta) CreateTimesheets(IEnumerable<Timesheet> timesheets);
+        (IList<Timesheet>, ResultsMeta) CreateTimesheets(
+            IEnumerable<Timesheet> timesheets);
 
         /// <summary>
         /// Create Timesheets.
@@ -4063,7 +6661,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Timesheet"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (Timesheet, ResultsMeta) CreateTimesheet(Timesheet timesheet);
+        (Timesheet, ResultsMeta) CreateTimesheet(
+            Timesheet timesheet);
 
         /// <summary>
         /// Asynchronously Create Timesheets.
@@ -4078,7 +6677,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Timesheet"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(IEnumerable<Timesheet> timesheets);
+        Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets);
+
+        /// <summary>
+        /// Asynchronously Create Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more timesheets to your company.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Timesheet"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Timesheets.
@@ -4093,7 +6713,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Timesheet"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(Timesheet, ResultsMeta)> CreateTimesheetAsync(Timesheet timesheet);
+        Task<(Timesheet, ResultsMeta)> CreateTimesheetAsync(
+            Timesheet timesheet);
+
+        /// <summary>
+        /// Asynchronously Create Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single timesheet to your company.
+        /// </remarks>
+        /// <param name="timesheet">
+        /// The <see cref="Timesheet"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Timesheet"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Timesheet, ResultsMeta)> CreateTimesheetAsync(
+            Timesheet timesheet,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieve Timesheets.
@@ -4151,6 +6792,27 @@ namespace Intuit.TSheets.Api
             TimesheetFilter filter);
 
         /// <summary>
+        /// Asynchronously Retrieve Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Timesheet"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Timesheet>, ResultsMeta)> GetTimesheetsAsync(
+            TimesheetFilter filter,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Timesheets.
         /// </summary>
         /// <remarks>
@@ -4170,6 +6832,31 @@ namespace Intuit.TSheets.Api
         Task<(IList<Timesheet>, ResultsMeta)> GetTimesheetsAsync(
             TimesheetFilter filter,
             RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Timesheet"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Timesheet>, ResultsMeta)> GetTimesheetsAsync(
+            TimesheetFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Update Timesheets.
@@ -4184,7 +6871,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Timesheet"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<Timesheet>, ResultsMeta) UpdateTimesheets(IEnumerable<Timesheet> timesheets);
+        (IList<Timesheet>, ResultsMeta) UpdateTimesheets(
+            IEnumerable<Timesheet> timesheets);
 
         /// <summary>
         /// Update Timesheets.
@@ -4219,6 +6907,26 @@ namespace Intuit.TSheets.Api
             IEnumerable<Timesheet> timesheets);
 
         /// <summary>
+        /// Asynchronously Update Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more timesheets in your company.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Timesheet"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Timesheet>, ResultsMeta)> UpdateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Update Timesheets.
         /// </summary>
         /// <remarks>
@@ -4235,6 +6943,26 @@ namespace Intuit.TSheets.Api
             Timesheet timesheet);
 
         /// <summary>
+        /// Asynchronously Update Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single timesheet in your company.
+        /// </remarks>
+        /// <param name="timesheet">
+        /// The <see cref="Timesheet"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Timesheet"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Timesheet, ResultsMeta)> UpdateTimesheetAsync(
+            Timesheet timesheet,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Delete Timesheets.
         /// </summary>
         /// <remarks>
@@ -4243,7 +6971,8 @@ namespace Intuit.TSheets.Api
         /// <param name="timesheet">
         /// The <see cref="Timesheet"/> object to be deleted.
         /// </param>
-        void DeleteTimesheet(Timesheet timesheet);
+        void DeleteTimesheet(
+            Timesheet timesheet);
 
         /// <summary>
         /// Delete Timesheets.
@@ -4254,7 +6983,8 @@ namespace Intuit.TSheets.Api
         /// <param name="timesheets">
         /// The set of <see cref="Timesheet"/> objects to be deleted.
         /// </param>
-        void DeleteTimesheets(IEnumerable<Timesheet> timesheets);
+        void DeleteTimesheets(
+            IEnumerable<Timesheet> timesheets);
 
         /// <summary>
         /// Delete Timesheets.
@@ -4265,7 +6995,8 @@ namespace Intuit.TSheets.Api
         /// <param name="id">
         /// The id of the <see cref="Timesheet"/> object to be deleted.
         /// </param>
-        void DeleteTimesheet(int id);
+        void DeleteTimesheet(
+            int id);
 
         /// <summary>
         /// Delete Timesheets.
@@ -4276,7 +7007,8 @@ namespace Intuit.TSheets.Api
         /// <param name="ids">
         /// The set of ids for the <see cref="Timesheet"/> objects to be deleted.
         /// </param>
-        void DeleteTimesheets(IEnumerable<int> ids);
+        void DeleteTimesheets(
+            IEnumerable<int> ids);
 
         /// <summary>
         /// Asynchronously Delete Timesheets.
@@ -4288,7 +7020,25 @@ namespace Intuit.TSheets.Api
         /// The <see cref="Timesheet"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteTimesheetAsync(Timesheet timesheet);
+        Task DeleteTimesheetAsync(
+            Timesheet timesheet);
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="Timesheet"/> object.
+        /// </remarks>
+        /// <param name="timesheet">
+        /// The <see cref="Timesheet"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteTimesheetAsync(
+            Timesheet timesheet,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Timesheets.
@@ -4300,7 +7050,25 @@ namespace Intuit.TSheets.Api
         /// The set of <see cref="Timesheet"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteTimesheetsAsync(IEnumerable<Timesheet> timesheets);
+        Task DeleteTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets);
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Timesheet"/> objects.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Timesheets.
@@ -4312,7 +7080,25 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="Timesheet"/> object to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteTimesheetAsync(int id);
+        Task DeleteTimesheetAsync(
+            int id);
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete a single <see cref="Timesheet"/> object, by id.
+        /// </remarks>
+        /// <param name="id">
+        /// The id of the <see cref="Timesheet"/> object to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteTimesheetAsync(
+            int id,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Delete Timesheets.
@@ -4324,7 +7110,25 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="Timesheet"/> objects to be deleted.
         /// </param>
         /// <returns>The asynchronous task.</returns>
-        Task DeleteTimesheetsAsync(IEnumerable<int> ids);
+        Task DeleteTimesheetsAsync(
+            IEnumerable<int> ids);
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Timesheet"/> objects, by id.
+        /// </remarks>
+        /// <param name="ids">
+        /// The set of ids for the <see cref="Timesheet"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteTimesheetsAsync(
+            IEnumerable<int> ids,
+            CancellationToken cancellationToken);
 
         #endregion
 
@@ -4386,6 +7190,27 @@ namespace Intuit.TSheets.Api
             TimesheetsDeletedFilter filter);
 
         /// <summary>
+        /// Retrieve Deleted Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all deleted timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetsDeletedFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="TimesheetsDeleted"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<TimesheetsDeleted>, ResultsMeta)> GetTimesheetsDeletedAsync(
+            TimesheetsDeletedFilter filter,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Retrieve Deleted Timesheets.
         /// </summary>
         /// <remarks>
@@ -4406,6 +7231,31 @@ namespace Intuit.TSheets.Api
             TimesheetsDeletedFilter filter,
             RequestOptions options);
 
+        /// <summary>
+        /// Retrieve Deleted Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all deleted timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetsDeletedFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="TimesheetsDeleted"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<TimesheetsDeleted>, ResultsMeta)> GetTimesheetsDeletedAsync(
+            TimesheetsDeletedFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
         #endregion
 
         #region Users
@@ -4423,7 +7273,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="User"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<User>, ResultsMeta) CreateUsers(IEnumerable<User> users);
+        (IList<User>, ResultsMeta) CreateUsers(
+            IEnumerable<User> users);
 
         /// <summary>
         /// Create Users.
@@ -4438,7 +7289,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="User"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (User, ResultsMeta) CreateUser(User user);
+        (User, ResultsMeta) CreateUser(
+            User user);
 
         /// <summary>
         /// Asynchronously Create Users.
@@ -4453,7 +7305,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="User"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<User>, ResultsMeta)> CreateUsersAsync(IEnumerable<User> users);
+        Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
+            IEnumerable<User> users);
+
+        /// <summary>
+        /// Asynchronously Create Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more users to your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
+            IEnumerable<User> users,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Users.
@@ -4468,7 +7341,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="User"/> object that was created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(User, ResultsMeta)> CreateUserAsync(User user);
+        Task<(User, ResultsMeta)> CreateUserAsync(
+            User user);
+
+        /// <summary>
+        /// Asynchronously Create Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add a single user to your company.
+        /// </remarks>
+        /// <param name="user">
+        /// The <see cref="User"/> object to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="User"/> object that was created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(User, ResultsMeta)> CreateUserAsync(
+            User user,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieve Users.
@@ -4552,6 +7446,23 @@ namespace Intuit.TSheets.Api
         Task<(IList<User>, ResultsMeta)> GetUsersAsync();
 
         /// <summary>
+        /// Asynchronously Retrieve Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Users.
         /// </summary>
         /// <remarks>
@@ -4569,6 +7480,27 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Asynchronously Retrieve Users.
         /// </summary>
         /// <remarks>
@@ -4584,6 +7516,27 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<User>, ResultsMeta)> GetUsersAsync(
             UserFilter filter);
+
+        /// <summary>
+        /// Asynchronously Retrieve Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="UserFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            UserFilter filter,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Retrieve Users.
@@ -4607,6 +7560,31 @@ namespace Intuit.TSheets.Api
             RequestOptions options);
 
         /// <summary>
+        /// Asynchronously Retrieve Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="UserFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <param name="options">
+        /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            UserFilter filter,
+            RequestOptions options,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Update Users.
         /// </summary>
         /// <remarks>
@@ -4619,7 +7597,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="User"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<User>, ResultsMeta) UpdateUsers(IEnumerable<User> users);
+        (IList<User>, ResultsMeta) UpdateUsers(
+            IEnumerable<User> users);
 
         /// <summary>
         /// Update Users.
@@ -4634,7 +7613,8 @@ namespace Intuit.TSheets.Api
         /// The <see cref="User"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (User, ResultsMeta) UpdateUser(User user);
+        (User, ResultsMeta) UpdateUser(
+            User user);
 
         /// <summary>
         /// Asynchronously Update Users.
@@ -4649,7 +7629,28 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="User"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(IEnumerable<User> users);
+        Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
+            IEnumerable<User> users);
+
+        /// <summary>
+        /// Asynchronously Update Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more users in your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
+            IEnumerable<User> users,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Users.
@@ -4664,7 +7665,28 @@ namespace Intuit.TSheets.Api
         /// The <see cref="User"/> object that was updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(User, ResultsMeta)> UpdateUserAsync(User user);
+        Task<(User, ResultsMeta)> UpdateUserAsync(
+            User user);
+
+        /// <summary>
+        /// Asynchronously Update Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single user in your company.
+        /// </remarks>
+        /// <param name="user">
+        /// The <see cref="User"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="User"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(User, ResultsMeta)> UpdateUserAsync(
+            User user,
+            CancellationToken cancellationToken);
 
         #endregion
     }

--- a/Intuit.TSheets/Api/IDataService.cs
+++ b/Intuit.TSheets/Api/IDataService.cs
@@ -39,6 +39,20 @@ namespace Intuit.TSheets.Api
         /// Retrieves the user object for the currently authenticated user. This is the
         /// user that authenticated to TSheets during the OAuth2 authentication process.
         /// </remarks>
+        /// <returns>
+        /// An instance of the <see cref="User"/> class, representing the current user, along
+        /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
+        /// data.
+        /// </returns>
+        (User, ResultsMeta) GetCurrentUser();
+
+        /// <summary>
+        /// Retrieve the Current User.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves the user object for the currently authenticated user. This is the
+        /// user that authenticated to TSheets during the OAuth2 authentication process.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -47,7 +61,22 @@ namespace Intuit.TSheets.Api
         /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
         /// data.
         /// </returns>
-        (User, ResultsMeta) GetCurrentUser(RequestOptions options = null);
+        (User, ResultsMeta) GetCurrentUser(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve the Current User.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves the user object for the currently authenticated user. This is the
+        /// user that authenticated to TSheets during the OAuth2 authentication process.
+        /// </remarks>
+        /// <returns>
+        /// An instance of the <see cref="User"/> class, representing the current user, along
+        /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
+        /// data.
+        /// </returns>
+        Task<(User, ResultsMeta)> GetCurrentUserAsync();
 
         /// <summary>
         /// Asynchronously Retrieve the Current User.
@@ -64,7 +93,8 @@ namespace Intuit.TSheets.Api
         /// with an output instance of the <see cref="ResultsMeta"/> class containing additional
         /// data.
         /// </returns>
-        Task<(User, ResultsMeta)> GetCurrentUserAsync(RequestOptions options = null);
+        Task<(User, ResultsMeta)> GetCurrentUserAsync(
+            RequestOptions options);
 
         #endregion
 
@@ -77,6 +107,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all custom fields associated with your company,
         /// with filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<CustomField>, ResultsMeta) GetCustomFields();
+
+        /// <summary>
+        /// Retrieve Custom Fields.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -85,7 +128,24 @@ namespace Intuit.TSheets.Api
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
         (IList<CustomField>, ResultsMeta) GetCustomFields(
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Custom Fields.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<CustomField>, ResultsMeta) GetCustomFields(
+            CustomFieldFilter filter);
 
         /// <summary>
         /// Retrieve Custom Fields.
@@ -106,7 +166,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<CustomField>, ResultsMeta) GetCustomFields(
             CustomFieldFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Fields.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Custom Fields.
@@ -123,7 +196,24 @@ namespace Intuit.TSheets.Api
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
         Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Fields.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom fields associated with your company,
+        /// with filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="CustomField"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
+            CustomFieldFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Custom Fields.
@@ -144,7 +234,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<CustomField>, ResultsMeta)> GetCustomFieldsAsync(
             CustomFieldFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         #endregion
 
@@ -223,6 +313,23 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="Model.Filters.CustomFieldItemFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        (IList<CustomFieldItem>, ResultsMeta) GetCustomFieldItems(
+            Model.Filters.CustomFieldItemFilter filter);
+
+        /// <summary>
+        /// Retrieve Custom Field Items.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field items associated with a custom field,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="Model.Filters.CustomFieldItemFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -232,7 +339,24 @@ namespace Intuit.TSheets.Api
         /// </returns>
         (IList<CustomFieldItem>, ResultsMeta) GetCustomFieldItems(
             Model.Filters.CustomFieldItemFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Items.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field items associated with a custom field,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="Model.Filters.CustomFieldItemFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItem>, ResultsMeta)> GetCustomFieldItemsAsync(
+            Model.Filters.CustomFieldItemFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Custom Field Items.
@@ -253,7 +377,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(IList<CustomFieldItem>, ResultsMeta)> GetCustomFieldItemsAsync(
             Model.Filters.CustomFieldItemFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         /// <summary>
         /// Update Custom Field Items.
@@ -330,6 +454,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
         /// with options to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="Model.CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        (IList<CustomFieldItemFilter>, ResultsMeta) GetCustomFieldItemFilters();
+
+        /// <summary>
+        /// Retrieve Custom Field Item Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -337,7 +474,25 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Model.CustomFieldItemFilter"/> objects retrieved, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<CustomFieldItemFilter>, ResultsMeta) GetCustomFieldItemFilters(RequestOptions options = null);
+        (IList<CustomFieldItemFilter>, ResultsMeta) GetCustomFieldItemFilters(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Custom Field Item Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        (IList<CustomFieldItemFilter>, ResultsMeta) GetCustomFieldItemFilters(
+            CustomFieldItemFilterFilter filter);
 
         /// <summary>
         /// Retrieve Custom Field Item Filters.
@@ -358,7 +513,20 @@ namespace Intuit.TSheets.Api
         /// </returns>
         (IList<CustomFieldItemFilter>, ResultsMeta) GetCustomFieldItemFilters(
             CustomFieldItemFilterFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Custom Field Item Filters.
@@ -375,7 +543,24 @@ namespace Intuit.TSheets.Api
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
         Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a jobcode, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
+            CustomFieldItemFilterFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Custom Field Item Filters.
@@ -396,11 +581,24 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(IList<CustomFieldItemFilter>, ResultsMeta)> GetCustomFieldItemFiltersAsync(
             CustomFieldItemFilterFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         #endregion
 
         #region CustomFieldItemJobcodeFilters
+
+        /// <summary>
+        /// Retrieve Custom Field Item Jobcode Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        (IList<CustomFieldItemJobcodeFilter>, ResultsMeta) GetCustomFieldItemJobcodeFilters();
 
         /// <summary>
         /// Retrieve Custom Field Item Jobcode Filters.
@@ -416,7 +614,25 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<CustomFieldItemJobcodeFilter>, ResultsMeta) GetCustomFieldItemJobcodeFilters(RequestOptions options = null);
+        (IList<CustomFieldItemJobcodeFilter>, ResultsMeta) GetCustomFieldItemJobcodeFilters(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Custom Field Item Jobcode Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemJobcodeFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        (IList<CustomFieldItemJobcodeFilter>, ResultsMeta) GetCustomFieldItemJobcodeFilters(
+            CustomFieldItemJobcodeFilterFilter filter);
 
         /// <summary>
         /// Retrieve Custom Field Item Jobcode Filters.
@@ -437,7 +653,20 @@ namespace Intuit.TSheets.Api
         /// </returns>
         (IList<CustomFieldItemJobcodeFilter>, ResultsMeta) GetCustomFieldItemJobcodeFilters(
             CustomFieldItemJobcodeFilterFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Custom Field Item Jobcode Filters.
@@ -454,7 +683,24 @@ namespace Intuit.TSheets.Api
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
         Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item Jobcode Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemJobcodeFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemJobcodeFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
+            CustomFieldItemJobcodeFilterFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Custom Field Item Jobcode Filters.
@@ -475,11 +721,24 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(IList<CustomFieldItemJobcodeFilter>, ResultsMeta)> GetCustomFieldItemJobcodeFiltersAsync(
             CustomFieldItemJobcodeFilterFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         #endregion
 
         #region CustomFieldItemUserFilters
+
+        /// <summary>
+        /// Retrieve Custom Field Item User Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        (IList<CustomFieldItemUserFilter>, ResultsMeta) GetCustomFieldItemUserFilters();
 
         /// <summary>
         /// Retrieve Custom Field Item User Filters.
@@ -495,7 +754,25 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        (IList<CustomFieldItemUserFilter>, ResultsMeta) GetCustomFieldItemUserFilters(RequestOptions options = null);
+        (IList<CustomFieldItemUserFilter>, ResultsMeta) GetCustomFieldItemUserFilters(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Custom Field Item User Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemUserFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        (IList<CustomFieldItemUserFilter>, ResultsMeta) GetCustomFieldItemUserFilters(
+            CustomFieldItemUserFilterFilter filter);
 
         /// <summary>
         /// Retrieve Custom Field Item User Filters.
@@ -516,7 +793,20 @@ namespace Intuit.TSheets.Api
         /// </returns>
         (IList<CustomFieldItemUserFilter>, ResultsMeta) GetCustomFieldItemUserFilters(
             CustomFieldItemUserFilterFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Custom Field Item User Filters.
@@ -533,7 +823,24 @@ namespace Intuit.TSheets.Api
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
         Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Custom Field Item User Filters.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all custom field item filters associated with a user, user, or group,
+        /// with options to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="CustomFieldItemUserFilterFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItemUserFilter"/> objects retrieved, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
+            CustomFieldItemUserFilterFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Custom Field Item User Filters.
@@ -554,7 +861,7 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(IList<CustomFieldItemUserFilter>, ResultsMeta)> GetCustomFieldItemUserFiltersAsync(
             CustomFieldItemUserFilterFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         #endregion
 
@@ -685,6 +992,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all uploaded files, with
         /// optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<File>, ResultsMeta) GetFiles();
+
+        /// <summary>
+        /// Retrieve Files.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -692,7 +1012,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="File"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        (IList<File>, ResultsMeta) GetFiles(RequestOptions options = null);
+        (IList<File>, ResultsMeta) GetFiles(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Files.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="FileFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<File>, ResultsMeta) GetFiles(
+            FileFilter filter);
 
         /// <summary>
         /// Retrieve Files.
@@ -713,7 +1051,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<File>, ResultsMeta) GetFiles(
             FileFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Files.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<File>, ResultsMeta)> GetFilesAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Files.
@@ -729,7 +1080,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="File"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        Task<(IList<File>, ResultsMeta)> GetFilesAsync(RequestOptions options = null);
+        Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Files.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all uploaded files, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="FileFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="File"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<File>, ResultsMeta)> GetFilesAsync(
+            FileFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Files.
@@ -750,7 +1119,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<File>, ResultsMeta)> GetFilesAsync(
             FileFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         /// <summary>
         /// Update Files.
@@ -930,6 +1299,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all geofence configurations, with
         /// optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<GeofenceConfig>, ResultsMeta) GetGeofenceConfigs();
+
+        /// <summary>
+        /// Retrieve Geofence Configurations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -937,7 +1319,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        (IList<GeofenceConfig>, ResultsMeta) GetGeofenceConfigs(RequestOptions options = null);
+        (IList<GeofenceConfig>, ResultsMeta) GetGeofenceConfigs(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Geofence Configurations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeofenceConfigFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<GeofenceConfig>, ResultsMeta) GetGeofenceConfigs(
+            GeofenceConfigFilter filter);
 
         /// <summary>
         /// Retrieve Geofence Configurations.
@@ -958,7 +1358,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<GeofenceConfig>, ResultsMeta) GetGeofenceConfigs(
             GeofenceConfigFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Geofence Configurations.
@@ -974,7 +1387,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(RequestOptions options = null);
+        Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Geofence Configurations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all geofence configurations, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeofenceConfigFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="GeofenceConfig"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
+            GeofenceConfigFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Geofence Configurations.
@@ -995,7 +1426,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<GeofenceConfig>, ResultsMeta)> GetGeofenceConfigsAsync(
             GeofenceConfigFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         #endregion
 
@@ -1059,6 +1490,23 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="GeolocationFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Geolocation"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<Geolocation>, ResultsMeta) GetGeolocations(
+            GeolocationFilter filter);
+
+        /// <summary>
+        /// Retrieve Geolocations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of geolocations associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeolocationFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -1068,7 +1516,24 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<Geolocation>, ResultsMeta) GetGeolocations(
             GeolocationFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Geolocations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of geolocations associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GeolocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Geolocation"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Geolocation>, ResultsMeta)> GetGeolocationsAsync(
+            GeolocationFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Geolocations.
@@ -1089,7 +1554,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Geolocation>, ResultsMeta)> GetGeolocationsAsync(
             GeolocationFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         #endregion
 
@@ -1162,6 +1627,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of groups associated with your company, with
         /// optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<Group>, ResultsMeta) GetGroups();
+
+        /// <summary>
+        /// Retrieve Groups.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -1169,7 +1647,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Group"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        (IList<Group>, ResultsMeta) GetGroups(RequestOptions options = null);
+        (IList<Group>, ResultsMeta) GetGroups(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Groups.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GroupFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<Group>, ResultsMeta) GetGroups(
+            GroupFilter filter);
 
         /// <summary>
         /// Retrieve Groups.
@@ -1190,7 +1686,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<Group>, ResultsMeta) GetGroups(
             GroupFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Groups.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Group>, ResultsMeta)> GetGroupsAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Groups.
@@ -1206,7 +1715,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Group"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(RequestOptions options = null);
+        Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Groups.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of groups associated with your company, with
+        /// optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="GroupFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Group"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
+            GroupFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Groups.
@@ -1227,7 +1754,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Group>, ResultsMeta)> GetGroupsAsync(
             GroupFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         /// <summary>
         /// Update Groups.
@@ -1424,6 +1951,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all jobcodes associated with your company,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<Jobcode>, ResultsMeta) GetJobcodes();
+
+        /// <summary>
+        /// Retrieve Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -1431,7 +1971,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        (IList<Jobcode>, ResultsMeta) GetJobcodes(RequestOptions options = null);
+        (IList<Jobcode>, ResultsMeta) GetJobcodes(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<Jobcode>, ResultsMeta) GetJobcodes(
+            JobcodeFilter filter);
 
         /// <summary>
         /// Retrieve Jobcodes.
@@ -1452,7 +2010,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<Jobcode>, ResultsMeta) GetJobcodes(
             JobcodeFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Jobcodes.
@@ -1468,7 +2039,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(RequestOptions options = null);
+        Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcodes associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Jobcode"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
+            JobcodeFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Jobcodes.
@@ -1489,7 +2078,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Jobcode>, ResultsMeta)> GetJobcodesAsync(
             JobcodeFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         /// <summary>
         /// Update Jobcodes.
@@ -1623,6 +2212,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all jobcode assignments associated with users,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<JobcodeAssignment>, ResultsMeta) GetJobcodeAssignments();
+
+        /// <summary>
+        /// Retrieve Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -1630,7 +2232,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        (IList<JobcodeAssignment>, ResultsMeta) GetJobcodeAssignments(RequestOptions options = null);
+        (IList<JobcodeAssignment>, ResultsMeta) GetJobcodeAssignments(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeAssignmentFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<JobcodeAssignment>, ResultsMeta) GetJobcodeAssignments(
+            JobcodeAssignmentFilter filter);
 
         /// <summary>
         /// Retrieve Jobcode Assignments.
@@ -1651,7 +2271,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<JobcodeAssignment>, ResultsMeta) GetJobcodeAssignments(
             JobcodeAssignmentFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Jobcode Assignments.
@@ -1667,7 +2300,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(RequestOptions options = null);
+        Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all jobcode assignments associated with users,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="JobcodeAssignmentFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="JobcodeAssignment"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
+            JobcodeAssignmentFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Jobcode Assignments.
@@ -1688,7 +2339,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<JobcodeAssignment>, ResultsMeta)> GetJobcodeAssignmentsAsync(
             JobcodeAssignmentFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         /// <summary>
         /// Delete Jobcode Assignments.
@@ -1908,6 +2559,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all locations associated with your company,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<Location>, ResultsMeta) GetLocations();
+
+        /// <summary>
+        /// Retrieve Locations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -1915,7 +2579,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Location"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        (IList<Location>, ResultsMeta) GetLocations(RequestOptions options = null);
+        (IList<Location>, ResultsMeta) GetLocations(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Locations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<Location>, ResultsMeta) GetLocations(
+            LocationFilter filter);
 
         /// <summary>
         /// Retrieve Locations.
@@ -1936,7 +2618,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<Location>, ResultsMeta) GetLocations(
             LocationFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Locations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Location>, ResultsMeta)> GetLocationsAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Locations.
@@ -1952,7 +2647,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Location"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(RequestOptions options = null);
+        Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Locations.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
+            LocationFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Locations.
@@ -1973,7 +2686,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Location>, ResultsMeta)> GetLocationsAsync(
             LocationFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         /// <summary>
         /// Update Locations.
@@ -2046,6 +2759,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all locations maps associated with your company,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="LocationsMap"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<LocationsMap>, ResultsMeta) GetLocationsMaps();
+
+        /// <summary>
+        /// Retrieve Locations Maps.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations maps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -2053,7 +2779,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="LocationsMap"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        (IList<LocationsMap>, ResultsMeta) GetLocationsMaps(RequestOptions options = null);
+        (IList<LocationsMap>, ResultsMeta) GetLocationsMaps(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Locations Maps.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locations maps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationsMapFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="LocationsMap"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<LocationsMap>, ResultsMeta) GetLocationsMaps(
+            LocationsMapFilter filter);
 
         /// <summary>
         /// Retrieve Locations Maps.
@@ -2074,7 +2818,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<LocationsMap>, ResultsMeta) GetLocationsMaps(
             LocationsMapFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve LocationsMaps.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync();
 
         /// <summary>
         /// Asynchronously Retrieve LocationsMaps.
@@ -2090,7 +2847,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Location"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(RequestOptions options = null);
+        Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve LocationsMaps.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all locationsMaps associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="LocationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Location"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
+            LocationsMapFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve LocationsMaps.
@@ -2111,11 +2886,24 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<LocationsMap>, ResultsMeta)> GetLocationsMapsAsync(
             LocationsMapFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         #endregion
 
         #region ManagedClients
+
+        /// <summary>
+        /// Retrieve Managed Clients.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<ManagedClient>, ResultsMeta) GetManagedClients();
 
         /// <summary>
         /// Retrieve Managed Clients.
@@ -2131,7 +2919,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        (IList<ManagedClient>, ResultsMeta) GetManagedClients(RequestOptions options = null);
+        (IList<ManagedClient>, ResultsMeta) GetManagedClients(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Managed Clients.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ManagedClientFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<ManagedClient>, ResultsMeta) GetManagedClients(
+            ManagedClientFilter filter);
 
         /// <summary>
         /// Retrieve Managed Clients.
@@ -2152,7 +2958,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<ManagedClient>, ResultsMeta) GetManagedClients(
             ManagedClientFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Managed Clients.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Managed Clients.
@@ -2168,7 +2987,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(RequestOptions options = null);
+        Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Managed Clients.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of managed clients available from your account,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ManagedClientFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ManagedClient"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
+            ManagedClientFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Managed Clients.
@@ -2189,7 +3026,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<ManagedClient>, ResultsMeta)> GetManagedClientsAsync(
             ManagedClientFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         #endregion
 
@@ -2262,6 +3099,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all notifications associated with your company,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<Notification>, ResultsMeta) GetNotifications();
+
+        /// <summary>
+        /// Retrieve Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -2269,7 +3119,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Notification"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        (IList<Notification>, ResultsMeta) GetNotifications(RequestOptions options = null);
+        (IList<Notification>, ResultsMeta) GetNotifications(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="NotificationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<Notification>, ResultsMeta) GetNotifications(
+            NotificationFilter filter);
 
         /// <summary>
         /// Retrieve Notifications.
@@ -2290,7 +3158,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<Notification>, ResultsMeta) GetNotifications(
             NotificationFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Notifications.
@@ -2306,7 +3187,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="Notification"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(RequestOptions options = null);
+        Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all notifications associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="NotificationFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Notification"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
+            NotificationFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Notifications.
@@ -2327,7 +3226,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Notification>, ResultsMeta)> GetNotificationsAsync(
             NotificationFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         /// <summary>
         /// Delete Notifications.
@@ -2495,6 +3394,23 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="ReminderFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Reminder"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<Reminder>, ResultsMeta) GetReminders(
+            ReminderFilter filter);
+
+        /// <summary>
+        /// Retrieve Reminders.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all reminders associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ReminderFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -2504,7 +3420,24 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<Reminder>, ResultsMeta) GetReminders(
             ReminderFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Reminders.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all reminders associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ReminderFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Reminder"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Reminder>, ResultsMeta)> GetRemindersAsync(
+            ReminderFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Reminders.
@@ -2525,7 +3458,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Reminder>, ResultsMeta)> GetRemindersAsync(
             ReminderFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         /// <summary>
         /// Update Reminders.
@@ -2766,6 +3699,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all schedule calendars associated with your
         /// employees, with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<ScheduleCalendar>, ResultsMeta) GetScheduleCalendars();
+
+        /// <summary>
+        /// Retrieve Schedule Calendars.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -2773,7 +3719,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        (IList<ScheduleCalendar>, ResultsMeta) GetScheduleCalendars(RequestOptions options = null);
+        (IList<ScheduleCalendar>, ResultsMeta) GetScheduleCalendars(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Schedule Calendars.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleCalendarFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<ScheduleCalendar>, ResultsMeta) GetScheduleCalendars(
+            ScheduleCalendarFilter filter);
 
         /// <summary>
         /// Retrieve Schedule Calendars.
@@ -2794,7 +3758,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<ScheduleCalendar>, ResultsMeta) GetScheduleCalendars(
             ScheduleCalendarFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Schedule Calendars.
@@ -2810,7 +3787,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(RequestOptions options = null);
+        Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Calendars.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule calendars associated with your
+        /// employees, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleCalendarFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleCalendar"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
+            ScheduleCalendarFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Schedule Calendars.
@@ -2831,7 +3826,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<ScheduleCalendar>, ResultsMeta)> GetScheduleCalendarsAsync(
             ScheduleCalendarFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         #endregion
 
@@ -2907,6 +3902,23 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="ScheduleEventFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleEvent"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<ScheduleEvent>, ResultsMeta) GetScheduleEvents(
+            ScheduleEventFilter filter);
+
+        /// <summary>
+        /// Retrieve Schedule Events.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule events associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleEventFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -2916,7 +3928,24 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<ScheduleEvent>, ResultsMeta) GetScheduleEvents(
             ScheduleEventFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Schedule Events.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all schedule events associated with your employees
+        /// or company, with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="ScheduleEventFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="ScheduleEvent"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<ScheduleEvent>, ResultsMeta)> GetScheduleEventsAsync(
+            ScheduleEventFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Schedule Events.
@@ -2937,7 +3966,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<ScheduleEvent>, ResultsMeta)> GetScheduleEventsAsync(
             ScheduleEventFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         /// <summary>
         /// Update Schedule Events.
@@ -3076,6 +4105,23 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="TimesheetFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Timesheet"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<Timesheet>, ResultsMeta) GetTimesheets(
+            TimesheetFilter filter);
+
+        /// <summary>
+        /// Retrieve Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -3085,7 +4131,24 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<Timesheet>, ResultsMeta) GetTimesheets(
             TimesheetFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="Timesheet"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<Timesheet>, ResultsMeta)> GetTimesheetsAsync(
+            TimesheetFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Timesheets.
@@ -3106,7 +4169,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<Timesheet>, ResultsMeta)> GetTimesheetsAsync(
             TimesheetFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         /// <summary>
         /// Update Timesheets.
@@ -3277,6 +4340,23 @@ namespace Intuit.TSheets.Api
         /// <param name="filter">
         /// An instance of the <see cref="TimesheetsDeletedFilter"/> class, for narrowing down the results.
         /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="TimesheetsDeleted"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<TimesheetsDeleted>, ResultsMeta) GetTimesheetsDeleted(
+            TimesheetsDeletedFilter filter);
+
+        /// <summary>
+        /// Retrieve Deleted Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all deleted timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetsDeletedFilter"/> class, for narrowing down the results.
+        /// </param>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -3286,7 +4366,24 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<TimesheetsDeleted>, ResultsMeta) GetTimesheetsDeleted(
             TimesheetsDeletedFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Deleted Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all deleted timesheets associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="TimesheetsDeletedFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="TimesheetsDeleted"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<TimesheetsDeleted>, ResultsMeta)> GetTimesheetsDeletedAsync(
+            TimesheetsDeletedFilter filter);
 
         /// <summary>
         /// Retrieve Deleted Timesheets.
@@ -3307,7 +4404,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<TimesheetsDeleted>, ResultsMeta)> GetTimesheetsDeletedAsync(
             TimesheetsDeletedFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         #endregion
 
@@ -3380,6 +4477,19 @@ namespace Intuit.TSheets.Api
         /// Retrieves a list of all users associated with your company,
         /// with optional filters to narrow down the results.
         /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<User>, ResultsMeta) GetUsers();
+
+        /// <summary>
+        /// Retrieve Users.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
         /// <param name="options">
         /// An instance of the <see cref="RequestOptions"/> class, for customizing method processing.
         /// </param>
@@ -3387,7 +4497,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="User"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        (IList<User>, ResultsMeta) GetUsers(RequestOptions options = null);
+        (IList<User>, ResultsMeta) GetUsers(
+            RequestOptions options);
+
+        /// <summary>
+        /// Retrieve Users.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="UserFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        (IList<User>, ResultsMeta) GetUsers(
+            UserFilter filter);
 
         /// <summary>
         /// Retrieve Users.
@@ -3408,7 +4536,20 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         (IList<User>, ResultsMeta) GetUsers(
             UserFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Users.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<User>, ResultsMeta)> GetUsersAsync();
 
         /// <summary>
         /// Asynchronously Retrieve Users.
@@ -3424,7 +4565,25 @@ namespace Intuit.TSheets.Api
         /// An enumerable set of <see cref="User"/> objects, along with an output
         /// instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns> 
-        Task<(IList<User>, ResultsMeta)> GetUsersAsync(RequestOptions options = null);
+        Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            RequestOptions options);
+
+        /// <summary>
+        /// Asynchronously Retrieve Users.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a list of all users associated with your company,
+        /// with optional filters to narrow down the results.
+        /// </remarks>
+        /// <param name="filter">
+        /// An instance of the <see cref="UserFilter"/> class, for narrowing down the results.
+        /// </param>
+        /// <returns>
+        /// An enumerable set of <see cref="User"/> objects, along with an output
+        /// instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns> 
+        Task<(IList<User>, ResultsMeta)> GetUsersAsync(
+            UserFilter filter);
 
         /// <summary>
         /// Asynchronously Retrieve Users.
@@ -3445,7 +4604,7 @@ namespace Intuit.TSheets.Api
         /// </returns> 
         Task<(IList<User>, ResultsMeta)> GetUsersAsync(
             UserFilter filter,
-            RequestOptions options = null);
+            RequestOptions options);
 
         /// <summary>
         /// Update Users.

--- a/Intuit.TSheets/Api/IDataService.cs
+++ b/Intuit.TSheets/Api/IDataService.cs
@@ -369,22 +369,6 @@ namespace Intuit.TSheets.Api
         /// Create Custom Field Items.
         /// </summary>
         /// <remarks>
-        /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
-        /// </remarks>
-        /// <param name="customFieldItems">
-        /// The set of <see cref="CustomFieldItem"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<CustomFieldItem>, ResultsMeta resultsMeta) CreateCustomFieldItems(
-            IEnumerable<CustomFieldItem> customFieldItems);
-
-        /// <summary>
-        /// Create Custom Field Items.
-        /// </summary>
-        /// <remarks>
         /// Add a single <see cref="CustomFieldItem"/> object to a <see cref="CustomField"/>.
         /// </remarks>
         /// <param name="customFieldItem">
@@ -398,7 +382,7 @@ namespace Intuit.TSheets.Api
             CustomFieldItem customFieldItem);
 
         /// <summary>
-        /// Asynchronously Create Custom Field Items.
+        /// Create Custom Field Items.
         /// </summary>
         /// <remarks>
         /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
@@ -410,28 +394,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> CreateCustomFieldItemsAsync(
+        (IList<CustomFieldItem>, ResultsMeta resultsMeta) CreateCustomFieldItems(
             IEnumerable<CustomFieldItem> customFieldItems);
-
-        /// <summary>
-        /// Asynchronously Create Custom Field Items, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
-        /// </remarks>
-        /// <param name="customFieldItems">
-        /// The set of <see cref="CustomFieldItem"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> CreateCustomFieldItemsAsync(
-            IEnumerable<CustomFieldItem> customFieldItems,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Custom Field Items.
@@ -467,6 +431,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(CustomFieldItem, ResultsMeta)> CreateCustomFieldItemAsync(
             CustomFieldItem customFieldItem,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create Custom Field Items.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> CreateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems);
+
+        /// <summary>
+        /// Asynchronously Create Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more <see cref="CustomFieldItem"/> objects to a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> CreateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -595,22 +595,6 @@ namespace Intuit.TSheets.Api
         /// Update Custom Field Items.
         /// </summary>
         /// <remarks>
-        /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
-        /// </remarks>
-        /// <param name="customFieldItems">
-        /// The set of <see cref="CustomFieldItem"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<CustomFieldItem>, ResultsMeta resultsMeta) UpdateCustomFieldItems(
-            IEnumerable<CustomFieldItem> customFieldItems);
-
-        /// <summary>
-        /// Update Custom Field Items.
-        /// </summary>
-        /// <remarks>
         /// Update a single <see cref="CustomFieldItem"/> object on a <see cref="CustomField"/>.
         /// </remarks>
         /// <param name="customFieldItem">
@@ -624,7 +608,7 @@ namespace Intuit.TSheets.Api
             CustomFieldItem customFieldItem);
 
         /// <summary>
-        /// Asynchronously Update Custom Field Items.
+        /// Update Custom Field Items.
         /// </summary>
         /// <remarks>
         /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
@@ -636,28 +620,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> UpdateCustomFieldItemsAsync(
+        (IList<CustomFieldItem>, ResultsMeta resultsMeta) UpdateCustomFieldItems(
             IEnumerable<CustomFieldItem> customFieldItems);
-
-        /// <summary>
-        /// Asynchronously Update Custom Field Items, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
-        /// </remarks>
-        /// <param name="customFieldItems">
-        /// The set of <see cref="CustomFieldItem"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> UpdateCustomFieldItemsAsync(
-            IEnumerable<CustomFieldItem> customFieldItems,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Custom Field Items.
@@ -693,6 +657,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(CustomFieldItem, ResultsMeta)> UpdateCustomFieldItemAsync(
             CustomFieldItem customFieldItem,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Update Custom Field Items.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> UpdateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems);
+
+        /// <summary>
+        /// Asynchronously Update Custom Field Items, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="CustomFieldItem"/> objects on a <see cref="CustomField"/>.
+        /// </remarks>
+        /// <param name="customFieldItems">
+        /// The set of <see cref="CustomFieldItem"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="CustomFieldItem"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<CustomFieldItem>, ResultsMeta resultsMeta)> UpdateCustomFieldItemsAsync(
+            IEnumerable<CustomFieldItem> customFieldItems,
             CancellationToken cancellationToken);
 
         #endregion
@@ -1795,22 +1795,6 @@ namespace Intuit.TSheets.Api
         /// Update Files.
         /// </summary>
         /// <remarks>
-        /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="File"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<File>, ResultsMeta resultsMeta) UpdateFiles(
-            IEnumerable<File> files);
-
-        /// <summary>
-        /// Update Files.
-        /// </summary>
-        /// <remarks>
         /// Update a single <see cref="File"/> object that is/can be attached to a timesheet.
         /// </remarks>
         /// <param name="file">
@@ -1823,7 +1807,7 @@ namespace Intuit.TSheets.Api
         (File, ResultsMeta) UpdateFile(File file);
 
         /// <summary>
-        /// Asynchronously Update Files.
+        /// Update Files.
         /// </summary>
         /// <remarks>
         /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
@@ -1835,28 +1819,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="File"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
+        (IList<File>, ResultsMeta resultsMeta) UpdateFiles(
             IEnumerable<File> files);
-
-        /// <summary>
-        /// Asynchronously Update Files, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="File"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
-            IEnumerable<File> files,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Files.
@@ -1892,6 +1856,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(File, ResultsMeta)> UpdateFileAsync(
             File file,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Update Files.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="File"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
+            IEnumerable<File> files);
+
+        /// <summary>
+        /// Asynchronously Update Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Update one or more <see cref="File"/> objects that are/can be attached to timesheets.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="File"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<File>, ResultsMeta)> UpdateFilesAsync(
+            IEnumerable<File> files,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -1938,18 +1938,6 @@ namespace Intuit.TSheets.Api
         /// Delete Files.
         /// </summary>
         /// <remarks>
-        /// Delete one or more <see cref="File"/> objects.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be deleted.
-        /// </param>
-        void DeleteFiles(
-            IEnumerable<File> files);
-
-        /// <summary>
-        /// Delete Files.
-        /// </summary>
-        /// <remarks>
         /// Delete a single <see cref="File"/> object, by id.
         /// </remarks>
         /// <param name="id">
@@ -1957,6 +1945,18 @@ namespace Intuit.TSheets.Api
         /// </param>
         void DeleteFile(
             int id);
+
+        /// <summary>
+        /// Delete Files.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="File"/> objects.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be deleted.
+        /// </param>
+        void DeleteFiles(
+            IEnumerable<File> files);
 
         /// <summary>
         /// Delete Files.
@@ -2004,36 +2004,6 @@ namespace Intuit.TSheets.Api
         /// Asynchronously Delete Files.
         /// </summary>
         /// <remarks>
-        /// Delete one or more <see cref="File"/> objects.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be deleted.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        Task DeleteFilesAsync(
-            IEnumerable<File> files);
-
-        /// <summary>
-        /// Asynchronously Delete Files, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="File"/> objects.
-        /// </remarks>
-        /// <param name="files">
-        /// The set of <see cref="File"/> objects to be deleted.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        Task DeleteFilesAsync(
-            IEnumerable<File> files,
-            CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Asynchronously Delete Files.
-        /// </summary>
-        /// <remarks>
         /// Delete a single <see cref="File"/> object, by id.
         /// </remarks>
         /// <param name="id">
@@ -2058,6 +2028,36 @@ namespace Intuit.TSheets.Api
         /// <returns>The asynchronous task.</returns>
         Task DeleteFileAsync(
             int id,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Delete Files.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="File"/> objects.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be deleted.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteFilesAsync(
+            IEnumerable<File> files);
+
+        /// <summary>
+        /// Asynchronously Delete Files, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="File"/> objects.
+        /// </remarks>
+        /// <param name="files">
+        /// The set of <see cref="File"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteFilesAsync(
+            IEnumerable<File> files,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -2321,19 +2321,6 @@ namespace Intuit.TSheets.Api
         /// <summary>
         /// Create Geolocations.
         /// </summary>
-        /// <param name="geolocations">
-        /// The set of <see cref="Geolocation"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Geolocation"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Geolocation>, ResultsMeta) CreateGeolocations(
-            IEnumerable<Geolocation> geolocations);
-
-        /// <summary>
-        /// Create Geolocations.
-        /// </summary>
         /// <param name="geolocation">
         /// The <see cref="Geolocation"/> object to be created.
         /// </param>
@@ -2345,7 +2332,7 @@ namespace Intuit.TSheets.Api
             Geolocation geolocation);
 
         /// <summary>
-        /// Asynchronously Create Geolocations.
+        /// Create Geolocations.
         /// </summary>
         /// <param name="geolocations">
         /// The set of <see cref="Geolocation"/> objects to be created.
@@ -2354,25 +2341,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Geolocation"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
+        (IList<Geolocation>, ResultsMeta) CreateGeolocations(
             IEnumerable<Geolocation> geolocations);
-
-        /// <summary>
-        /// Asynchronously Create Geolocations, with support for cancellation.
-        /// </summary>
-        /// <param name="geolocations">
-        /// The set of <see cref="Geolocation"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Geolocation"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
-            IEnumerable<Geolocation> geolocations,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Geolocations.
@@ -2402,6 +2372,36 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(Geolocation, ResultsMeta)> CreateGeolocationAsync(
             Geolocation geolocation,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create Geolocations.
+        /// </summary>
+        /// <param name="geolocations">
+        /// The set of <see cref="Geolocation"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Geolocation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
+            IEnumerable<Geolocation> geolocations);
+
+        /// <summary>
+        /// Asynchronously Create Geolocations, with support for cancellation.
+        /// </summary>
+        /// <param name="geolocations">
+        /// The set of <see cref="Geolocation"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Geolocation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Geolocation>, ResultsMeta)> CreateGeolocationsAsync(
+            IEnumerable<Geolocation> geolocations,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -2534,22 +2534,6 @@ namespace Intuit.TSheets.Api
         /// Create Groups.
         /// </summary>
         /// <remarks>
-        /// Add one or more groups to your company.
-        /// </remarks>
-        /// <param name="groups">
-        /// The set of <see cref="Group"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Group"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Group>, ResultsMeta) CreateGroups(
-            IEnumerable<Group> groups);
-
-        /// <summary>
-        /// Create Groups.
-        /// </summary>
-        /// <remarks>
         /// Add a single group to your company.
         /// </remarks> 
         /// <param name="group">
@@ -2563,7 +2547,7 @@ namespace Intuit.TSheets.Api
             Group group);
 
         /// <summary>
-        /// Asynchronously Create Groups.
+        /// Create Groups.
         /// </summary>
         /// <remarks>
         /// Add one or more groups to your company.
@@ -2575,28 +2559,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Group"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
+        (IList<Group>, ResultsMeta) CreateGroups(
             IEnumerable<Group> groups);
-
-        /// <summary>
-        /// Asynchronously Create Groups, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more groups to your company.
-        /// </remarks>
-        /// <param name="groups">
-        /// The set of <see cref="Group"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Group"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
-            IEnumerable<Group> groups,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Groups.
@@ -2632,6 +2596,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(Group, ResultsMeta)> CreateGroupAsync(
             Group group,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create Groups.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more groups to your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
+            IEnumerable<Group> groups);
+
+        /// <summary>
+        /// Asynchronously Create Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more groups to your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Group>, ResultsMeta)> CreateGroupsAsync(
+            IEnumerable<Group> groups,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -2858,22 +2858,6 @@ namespace Intuit.TSheets.Api
         /// Update Groups.
         /// </summary>
         /// <remarks>
-        /// Edit one or more groups in your company.
-        /// </remarks>
-        /// <param name="groups">
-        /// The set of <see cref="Group"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Group"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Group>, ResultsMeta) UpdateGroups(
-            IEnumerable<Group> groups);
-
-        /// <summary>
-        /// Update Groups.
-        /// </summary>
-        /// <remarks>
         /// Edit a single group in your company.
         /// </remarks>
         /// <param name="group">
@@ -2887,7 +2871,7 @@ namespace Intuit.TSheets.Api
             Group group);
 
         /// <summary>
-        /// Asynchronously Update Groups.
+        /// Update Groups.
         /// </summary>
         /// <remarks>
         /// Edit one or more groups in your company.
@@ -2899,28 +2883,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Group"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
+        (IList<Group>, ResultsMeta) UpdateGroups(
             IEnumerable<Group> groups);
-
-        /// <summary>
-        /// Asynchronously Update Groups, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more groups in your company.
-        /// </remarks>
-        /// <param name="groups">
-        /// The set of <see cref="Group"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Group"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
-            IEnumerable<Group> groups,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Groups.
@@ -2958,25 +2922,45 @@ namespace Intuit.TSheets.Api
             Group group,
             CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Asynchronously Update Groups.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more groups in your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
+            IEnumerable<Group> groups);
+
+        /// <summary>
+        /// Asynchronously Update Groups, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more groups in your company.
+        /// </remarks>
+        /// <param name="groups">
+        /// The set of <see cref="Group"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Group"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Group>, ResultsMeta)> UpdateGroupsAsync(
+            IEnumerable<Group> groups,
+            CancellationToken cancellationToken);
+
         #endregion
 
         #region Invitations
-
-        /// <summary>
-        /// Create Invitations.
-        /// </summary>
-        /// <remarks>
-        /// Invite one or more users to your company.
-        /// </remarks>
-        /// <param name="invitations">
-        /// The set of <see cref="Invitation"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Invitation"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Invitation>, ResultsMeta) CreateInvitations(
-            IEnumerable<Invitation> invitations);
 
         /// <summary>
         /// Create Invitations.
@@ -2995,7 +2979,7 @@ namespace Intuit.TSheets.Api
             Invitation invitation);
 
         /// <summary>
-        /// Asynchronously Create Invitations.
+        /// Create Invitations.
         /// </summary>
         /// <remarks>
         /// Invite one or more users to your company.
@@ -3007,28 +2991,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Invitation"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
+        (IList<Invitation>, ResultsMeta) CreateInvitations(
             IEnumerable<Invitation> invitations);
-
-        /// <summary>
-        /// Asynchronously Create Invitations, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Invite one or more users to your company.
-        /// </remarks>
-        /// <param name="invitations">
-        /// The set of <see cref="Invitation"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Invitation"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
-            IEnumerable<Invitation> invitations,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create An Invitation.
@@ -3066,25 +3030,45 @@ namespace Intuit.TSheets.Api
             Invitation invitation,
             CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Asynchronously Create Invitations.
+        /// </summary>
+        /// <remarks>
+        /// Invite one or more users to your company.
+        /// </remarks>
+        /// <param name="invitations">
+        /// The set of <see cref="Invitation"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Invitation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
+            IEnumerable<Invitation> invitations);
+
+        /// <summary>
+        /// Asynchronously Create Invitations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Invite one or more users to your company.
+        /// </remarks>
+        /// <param name="invitations">
+        /// The set of <see cref="Invitation"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Invitation"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Invitation>, ResultsMeta)> CreateInvitationsAsync(
+            IEnumerable<Invitation> invitations,
+            CancellationToken cancellationToken);
+
         #endregion
 
         #region Jobcodes
-
-        /// <summary>
-        /// Create Jobcodes.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more jobcodes to your company.
-        /// </remarks>
-        /// <param name="jobcodes">
-        /// The set of <see cref="Jobcode"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Jobcode"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Jobcode>, ResultsMeta) CreateJobcodes(
-            IEnumerable<Jobcode> jobcodes);
 
         /// <summary>
         /// Create Jobcodes.
@@ -3103,7 +3087,7 @@ namespace Intuit.TSheets.Api
             Jobcode jobcode);
 
         /// <summary>
-        /// Asynchronously Create Jobcodes.
+        /// Create Jobcodes.
         /// </summary>
         /// <remarks>
         /// Add one or more jobcodes to your company.
@@ -3115,28 +3099,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Jobcode"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
+        (IList<Jobcode>, ResultsMeta) CreateJobcodes(
             IEnumerable<Jobcode> jobcodes);
-
-        /// <summary>
-        /// Asynchronously Create Jobcodes, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more jobcodes to your company.
-        /// </remarks>
-        /// <param name="jobcodes">
-        /// The set of <see cref="Jobcode"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Jobcode"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
-            IEnumerable<Jobcode> jobcodes,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create A Jobcode.
@@ -3172,6 +3136,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(Jobcode, ResultsMeta)> CreateJobcodeAsync(
             Jobcode jobcode,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcodes to your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Jobcode"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes);
+
+        /// <summary>
+        /// Asynchronously Create Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcodes to your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Jobcode"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Jobcode>, ResultsMeta)> CreateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -3398,22 +3398,6 @@ namespace Intuit.TSheets.Api
         /// Update Jobcodes.
         /// </summary>
         /// <remarks>
-        /// Edit one or more jobcodes in your company.
-        /// </remarks>
-        /// <param name="jobcodes">
-        /// The set of <see cref="Jobcode"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Jobcode"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Jobcode>, ResultsMeta) UpdateJobcodes(
-            IEnumerable<Jobcode> jobcodes);
-
-        /// <summary>
-        /// Update Jobcodes.
-        /// </summary>
-        /// <remarks>
         /// Edit a single jobcode in your company.
         /// </remarks>
         /// <param name="jobcode">
@@ -3427,7 +3411,7 @@ namespace Intuit.TSheets.Api
             Jobcode jobcode);
 
         /// <summary>
-        /// Asynchronously Update Jobcodes.
+        /// Update Jobcodes.
         /// </summary>
         /// <remarks>
         /// Edit one or more jobcodes in your company.
@@ -3439,28 +3423,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Jobcode"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
+        (IList<Jobcode>, ResultsMeta) UpdateJobcodes(
             IEnumerable<Jobcode> jobcodes);
-
-        /// <summary>
-        /// Asynchronously Update Jobcodes, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more jobcodes in your company.
-        /// </remarks>
-        /// <param name="jobcodes">
-        /// The set of <see cref="Jobcode"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Jobcode"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
-            IEnumerable<Jobcode> jobcodes,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Jobcodes.
@@ -3498,25 +3462,45 @@ namespace Intuit.TSheets.Api
             Jobcode jobcode,
             CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Asynchronously Update Jobcodes.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more jobcodes in your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Jobcode"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes);
+
+        /// <summary>
+        /// Asynchronously Update Jobcodes, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more jobcodes in your company.
+        /// </remarks>
+        /// <param name="jobcodes">
+        /// The set of <see cref="Jobcode"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Jobcode"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Jobcode>, ResultsMeta)> UpdateJobcodesAsync(
+            IEnumerable<Jobcode> jobcodes,
+            CancellationToken cancellationToken);
+
         #endregion
 
         #region JobcodeAssignments
-
-        /// <summary>
-        /// Create Jobcode Assignments.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more jobcode assignments to a user.
-        /// </remarks>
-        /// <param name="jobcodeAssignments">
-        /// The set of <see cref="JobcodeAssignment"/> assignments to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<JobcodeAssignment>, ResultsMeta) CreateJobcodeAssignments(
-            IEnumerable<JobcodeAssignment> jobcodeAssignments);
 
         /// <summary>
         /// Create Jobcode Assignments.
@@ -3535,7 +3519,7 @@ namespace Intuit.TSheets.Api
             JobcodeAssignment jobcodeAssignment);
 
         /// <summary>
-        /// Asynchronously Create Jobcode Assignments.
+        /// Create Jobcode Assignments.
         /// </summary>
         /// <remarks>
         /// Add one or more jobcode assignments to a user.
@@ -3547,28 +3531,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
+        (IList<JobcodeAssignment>, ResultsMeta) CreateJobcodeAssignments(
             IEnumerable<JobcodeAssignment> jobcodeAssignments);
-
-        /// <summary>
-        /// Asynchronously Create Jobcode Assignments, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more jobcode assignments to a user.
-        /// </remarks>
-        /// <param name="jobcodeAssignments">
-        /// The set of <see cref="JobcodeAssignment"/> assignments to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
-            IEnumerable<JobcodeAssignment> jobcodeAssignments,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Jobcode Assignments.
@@ -3604,6 +3568,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(JobcodeAssignment, ResultsMeta)> CreateJobcodeAssignmentAsync(
             JobcodeAssignment jobcodeAssignment,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcode assignments to a user.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignments to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments);
+
+        /// <summary>
+        /// Asynchronously Create Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more jobcode assignments to a user.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignments to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="JobcodeAssignment"/> assignments that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<JobcodeAssignment>, ResultsMeta)> CreateJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -3842,18 +3842,6 @@ namespace Intuit.TSheets.Api
         /// Delete Jobcode Assignments.
         /// </summary>
         /// <remarks>
-        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
-        /// </remarks>
-        /// <param name="jobcodeAssignments">
-        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
-        /// </param>
-        void DeleteJobcodeAssignments(
-            IEnumerable<JobcodeAssignment> jobcodeAssignments);
-
-        /// <summary>
-        /// Delete Jobcode Assignments.
-        /// </summary>
-        /// <remarks>
         /// Delete a single <see cref="JobcodeAssignment"/> assignment, by id.
         /// </remarks>
         /// <param name="id">
@@ -3861,6 +3849,18 @@ namespace Intuit.TSheets.Api
         /// </param>
         void DeleteJobcodeAssignment(
             int id);
+
+        /// <summary>
+        /// Delete Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
+        /// </param>
+        void DeleteJobcodeAssignments(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments);
 
         /// <summary>
         /// Delete Jobcode Assignments.
@@ -3908,36 +3908,6 @@ namespace Intuit.TSheets.Api
         /// Asynchronously Delete Jobcode Assignments.
         /// </summary>
         /// <remarks>
-        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
-        /// </remarks>
-        /// <param name="jobcodeAssignments">
-        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        Task DeleteJobcodeAssignmentsAsync(
-            IEnumerable<JobcodeAssignment> jobcodeAssignments);
-
-        /// <summary>
-        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
-        /// </remarks>
-        /// <param name="jobcodeAssignments">
-        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        Task DeleteJobcodeAssignmentsAsync(
-            IEnumerable<JobcodeAssignment> jobcodeAssignments,
-            CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Asynchronously Delete Jobcode Assignments.
-        /// </summary>
-        /// <remarks>
         /// Delete a single <see cref="JobcodeAssignment"/> assignment, by id.
         /// </remarks>
         /// <param name="id">
@@ -3962,6 +3932,36 @@ namespace Intuit.TSheets.Api
         /// <returns>The asynchronous task.</returns>
         Task DeleteJobcodeAssignmentAsync(
             int id,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments);
+
+        /// <summary>
+        /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="JobcodeAssignment"/> assignments.
+        /// </remarks>
+        /// <param name="jobcodeAssignments">
+        /// The set of <see cref="JobcodeAssignment"/> assignment objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteJobcodeAssignmentsAsync(
+            IEnumerable<JobcodeAssignment> jobcodeAssignments,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -4092,22 +4092,6 @@ namespace Intuit.TSheets.Api
         /// Create Locations.
         /// </summary>
         /// <remarks>
-        /// Add one or more locations to your company.
-        /// </remarks>
-        /// <param name="locations">
-        /// The set of <see cref="Location"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Location"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Location>, ResultsMeta) CreateLocations(
-            IEnumerable<Location> locations);
-
-        /// <summary>
-        /// Create Locations.
-        /// </summary>
-        /// <remarks>
         /// Add a single location to your company.
         /// </remarks>
         /// <param name="location">
@@ -4121,7 +4105,7 @@ namespace Intuit.TSheets.Api
             Location location);
 
         /// <summary>
-        /// Asynchronously Create Locations.
+        /// Create Locations.
         /// </summary>
         /// <remarks>
         /// Add one or more locations to your company.
@@ -4133,28 +4117,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Location"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
+        (IList<Location>, ResultsMeta) CreateLocations(
             IEnumerable<Location> locations);
-
-        /// <summary>
-        /// Asynchronously Create Locations, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more locations to your company.
-        /// </remarks>
-        /// <param name="locations">
-        /// The set of <see cref="Location"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Location"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
-            IEnumerable<Location> locations,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Locations.
@@ -4190,6 +4154,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(Location, ResultsMeta)> CreateLocationAsync(
             Location location,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create Locations.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more locations to your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
+            IEnumerable<Location> locations);
+
+        /// <summary>
+        /// Asynchronously Create Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more locations to your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Location>, ResultsMeta)> CreateLocationsAsync(
+            IEnumerable<Location> locations,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -4416,22 +4416,6 @@ namespace Intuit.TSheets.Api
         /// Update Locations.
         /// </summary>
         /// <remarks>
-        /// Edit one or more locations in your company.
-        /// </remarks>
-        /// <param name="locations">
-        /// The set of <see cref="Location"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Location"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Location>, ResultsMeta) UpdateLocations(
-            IEnumerable<Location> locations);
-
-        /// <summary>
-        /// Update Locations.
-        /// </summary>
-        /// <remarks>
         /// Edit a single location in your company.
         /// </remarks>
         /// <param name="location">
@@ -4445,7 +4429,7 @@ namespace Intuit.TSheets.Api
             Location location);
 
         /// <summary>
-        /// Asynchronously Update Locations.
+        /// Update Locations.
         /// </summary>
         /// <remarks>
         /// Edit one or more locations in your company.
@@ -4457,28 +4441,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Location"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
+        (IList<Location>, ResultsMeta) UpdateLocations(
             IEnumerable<Location> locations);
-
-        /// <summary>
-        /// Asynchronously Update Locations, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more locations in your company.
-        /// </remarks>
-        /// <param name="locations">
-        /// The set of <see cref="Location"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Location"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
-            IEnumerable<Location> locations,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Locations.
@@ -4514,6 +4478,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(Location, ResultsMeta)> UpdateLocationAsync(
             Location location,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Update Locations.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more locations in your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
+            IEnumerable<Location> locations);
+
+        /// <summary>
+        /// Asynchronously Update Locations, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more locations in your company.
+        /// </remarks>
+        /// <param name="locations">
+        /// The set of <see cref="Location"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Location"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Location>, ResultsMeta)> UpdateLocationsAsync(
+            IEnumerable<Location> locations,
             CancellationToken cancellationToken);
 
         #endregion
@@ -4972,22 +4972,6 @@ namespace Intuit.TSheets.Api
         /// Create Notifications.
         /// </summary>
         /// <remarks>
-        /// Add one or more notifications.
-        /// </remarks>
-        /// <param name="notifications">
-        /// The set of <see cref="Notification"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Notification"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Notification>, ResultsMeta) CreateNotifications(
-            IEnumerable<Notification> notifications);
-
-        /// <summary>
-        /// Create Notifications.
-        /// </summary>
-        /// <remarks>
         /// Add a single notification.
         /// </remarks>
         /// <param name="notification">
@@ -5001,7 +4985,7 @@ namespace Intuit.TSheets.Api
             Notification notification);
 
         /// <summary>
-        /// Asynchronously Create Notifications.
+        /// Create Notifications.
         /// </summary>
         /// <remarks>
         /// Add one or more notifications.
@@ -5013,28 +4997,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Notification"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
+        (IList<Notification>, ResultsMeta) CreateNotifications(
             IEnumerable<Notification> notifications);
-
-        /// <summary>
-        /// Asynchronously Create Notifications, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more notifications.
-        /// </remarks>
-        /// <param name="notifications">
-        /// The set of <see cref="Notification"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Notification"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
-            IEnumerable<Notification> notifications,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Notifications.
@@ -5070,6 +5034,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(Notification, ResultsMeta)> CreateNotificationAsync(
             Notification notification,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more notifications.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Notification"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
+            IEnumerable<Notification> notifications);
+
+        /// <summary>
+        /// Asynchronously Create Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more notifications.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Notification"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Notification>, ResultsMeta)> CreateNotificationsAsync(
+            IEnumerable<Notification> notifications,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -5309,18 +5309,6 @@ namespace Intuit.TSheets.Api
         /// Delete Notifications.
         /// </summary>
         /// <remarks>
-        /// Delete one or more <see cref="Notification"/> objects.
-        /// </remarks>
-        /// <param name="notifications">
-        /// The set of <see cref="Notification"/> objects to be deleted.
-        /// </param>
-        void DeleteNotifications(
-            IEnumerable<Notification> notifications);
-
-        /// <summary>
-        /// Delete Notifications.
-        /// </summary>
-        /// <remarks>
         /// Delete a single <see cref="Notification"/> object, by id.
         /// </remarks>
         /// <param name="id">
@@ -5328,6 +5316,18 @@ namespace Intuit.TSheets.Api
         /// </param>
         void DeleteNotification(
             int id);
+
+        /// <summary>
+        /// Delete Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Notification"/> objects.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be deleted.
+        /// </param>
+        void DeleteNotifications(
+            IEnumerable<Notification> notifications);
 
         /// <summary>
         /// Delete Notifications.
@@ -5375,36 +5375,6 @@ namespace Intuit.TSheets.Api
         /// Asynchronously Delete Notifications.
         /// </summary>
         /// <remarks>
-        /// Delete one or more <see cref="Notification"/> objects.
-        /// </remarks>
-        /// <param name="notifications">
-        /// The set of <see cref="Notification"/> objects to be deleted.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        Task DeleteNotificationsAsync(
-            IEnumerable<Notification> notifications);
-
-        /// <summary>
-        /// Asynchronously Delete Notifications, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="Notification"/> objects.
-        /// </remarks>
-        /// <param name="notifications">
-        /// The set of <see cref="Notification"/> objects to be deleted.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        Task DeleteNotificationsAsync(
-            IEnumerable<Notification> notifications,
-            CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Asynchronously Delete Notifications.
-        /// </summary>
-        /// <remarks>
         /// Delete a single <see cref="Notification"/> object, by id.
         /// </remarks>
         /// <param name="id">
@@ -5429,6 +5399,36 @@ namespace Intuit.TSheets.Api
         /// <returns>The asynchronous task.</returns>
         Task DeleteNotificationAsync(
             int id,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Delete Notifications.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Notification"/> objects.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be deleted.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteNotificationsAsync(
+            IEnumerable<Notification> notifications);
+
+        /// <summary>
+        /// Asynchronously Delete Notifications, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Notification"/> objects.
+        /// </remarks>
+        /// <param name="notifications">
+        /// The set of <see cref="Notification"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteNotificationsAsync(
+            IEnumerable<Notification> notifications,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -5469,22 +5469,6 @@ namespace Intuit.TSheets.Api
         /// Create Reminders.
         /// </summary>
         /// <remarks>
-        /// Add one or more user-specific or company-wide reminders.
-        /// </remarks>
-        /// <param name="reminders">
-        /// The set of <see cref="Reminder"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Reminder"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Reminder>, ResultsMeta) CreateReminders(
-            IEnumerable<Reminder> reminders);
-
-        /// <summary>
-        /// Create Reminders.
-        /// </summary>
-        /// <remarks>
         /// Add a single user-specific or company-wide reminder.
         /// </remarks>
         /// <param name="reminder">
@@ -5498,7 +5482,7 @@ namespace Intuit.TSheets.Api
             Reminder reminder);
 
         /// <summary>
-        /// Asynchronously Create Reminders.
+        /// Create Reminders.
         /// </summary>
         /// <remarks>
         /// Add one or more user-specific or company-wide reminders.
@@ -5510,28 +5494,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Reminder"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
+        (IList<Reminder>, ResultsMeta) CreateReminders(
             IEnumerable<Reminder> reminders);
-
-        /// <summary>
-        /// Asynchronously Create Reminders, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more user-specific or company-wide reminders.
-        /// </remarks>
-        /// <param name="reminders">
-        /// The set of <see cref="Reminder"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Reminder"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
-            IEnumerable<Reminder> reminders,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Reminders.
@@ -5567,6 +5531,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(Reminder, ResultsMeta)> CreateReminderAsync(
             Reminder reminder,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create Reminders.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more user-specific or company-wide reminders.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
+            IEnumerable<Reminder> reminders);
+
+        /// <summary>
+        /// Asynchronously Create Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more user-specific or company-wide reminders.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Reminder>, ResultsMeta)> CreateRemindersAsync(
+            IEnumerable<Reminder> reminders,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -5695,22 +5695,6 @@ namespace Intuit.TSheets.Api
         /// Update Reminders.
         /// </summary>
         /// <remarks>
-        /// Edit one or more reminders for employees within your company.
-        /// </remarks>
-        /// <param name="reminders">
-        /// The set of <see cref="Reminder"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Reminder"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Reminder>, ResultsMeta) UpdateReminders(
-            IEnumerable<Reminder> reminders);
-
-        /// <summary>
-        /// Update Reminders.
-        /// </summary>
-        /// <remarks>
         /// Edit a single reminder for employees within your company.
         /// </remarks>
         /// <param name="reminder">
@@ -5724,7 +5708,7 @@ namespace Intuit.TSheets.Api
             Reminder reminder);
 
         /// <summary>
-        /// Asynchronously Update Reminders.
+        /// Update Reminders.
         /// </summary>
         /// <remarks>
         /// Edit one or more reminders for employees within your company.
@@ -5736,28 +5720,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Reminder"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Reminder>, ResultsMeta)> UpdateRemindersAsync(
+        (IList<Reminder>, ResultsMeta) UpdateReminders(
             IEnumerable<Reminder> reminders);
-
-        /// <summary>
-        /// Asynchronously Update Reminders, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more reminders for employees within your company.
-        /// </remarks>
-        /// <param name="reminders">
-        /// The set of <see cref="Reminder"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Reminder"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Reminder>, ResultsMeta)> UpdateRemindersAsync(
-            IEnumerable<Reminder> reminders,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Reminders.
@@ -5793,6 +5757,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(Reminder, ResultsMeta)> UpdateReminderAsync(
             Reminder reminder,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Update Reminders.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more reminders for employees within your company.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Reminder>, ResultsMeta)> UpdateRemindersAsync(
+            IEnumerable<Reminder> reminders);
+
+        /// <summary>
+        /// Asynchronously Update Reminders, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more reminders for employees within your company.
+        /// </remarks>
+        /// <param name="reminders">
+        /// The set of <see cref="Reminder"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Reminder"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Reminder>, ResultsMeta)> UpdateRemindersAsync(
+            IEnumerable<Reminder> reminders,
             CancellationToken cancellationToken);
 
         #endregion
@@ -6299,22 +6299,6 @@ namespace Intuit.TSheets.Api
         #region ScheduleEvents
 
         /// <summary>
-        /// Create Schedule Events.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more schedule events.
-        /// </remarks>
-        /// <param name="scheduleEvents">
-        /// The set of <see cref="ScheduleEvent"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<ScheduleEvent>, ResultsMeta) CreateScheduleEvents(
-            IEnumerable<ScheduleEvent> scheduleEvents);
-
-        /// <summary>
         /// Create ScheduleEvents.
         /// </summary>
         /// <remarks>
@@ -6331,7 +6315,7 @@ namespace Intuit.TSheets.Api
             ScheduleEvent scheduleEvent);
 
         /// <summary>
-        /// Asynchronously Create Schedule Events.
+        /// Create Schedule Events.
         /// </summary>
         /// <remarks>
         /// Add one or more schedule events.
@@ -6343,28 +6327,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
+        (IList<ScheduleEvent>, ResultsMeta) CreateScheduleEvents(
             IEnumerable<ScheduleEvent> scheduleEvents);
-
-        /// <summary>
-        /// Asynchronously Create Schedule Events, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more schedule events.
-        /// </remarks>
-        /// <param name="scheduleEvents">
-        /// The set of <see cref="ScheduleEvent"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
-            IEnumerable<ScheduleEvent> scheduleEvents,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create ScheduleEvents.
@@ -6403,6 +6367,42 @@ namespace Intuit.TSheets.Api
             CancellationToken cancellationToken);
 
         /// <summary>
+        /// Asynchronously Create Schedule Events.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents);
+
+        /// <summary>
+        /// Asynchronously Create Schedule Events, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<ScheduleEvent>, ResultsMeta)> CreateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Retrieve Schedule Events.
         /// </summary>
         /// <remarks>
@@ -6525,22 +6525,6 @@ namespace Intuit.TSheets.Api
             CancellationToken cancellationToken);
 
         /// <summary>
-        /// Update Schedule Events.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more schedule events.
-        /// </remarks>
-        /// <param name="scheduleEvents">
-        /// The set of <see cref="ScheduleEvent"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<ScheduleEvent>, ResultsMeta) UpdateScheduleEvents(
-            IEnumerable<ScheduleEvent> scheduleEvents);
-
-        /// <summary>
         /// Update ScheduleEvents.
         /// </summary>
         /// <remarks>
@@ -6557,7 +6541,7 @@ namespace Intuit.TSheets.Api
             ScheduleEvent scheduleEvent);
 
         /// <summary>
-        /// Asynchronously Update ScheduleEvents.
+        /// Update Schedule Events.
         /// </summary>
         /// <remarks>
         /// Edit one or more schedule events.
@@ -6569,28 +6553,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<ScheduleEvent>, ResultsMeta)> UpdateScheduleEventsAsync(
+        (IList<ScheduleEvent>, ResultsMeta) UpdateScheduleEvents(
             IEnumerable<ScheduleEvent> scheduleEvents);
-
-        /// <summary>
-        /// Asynchronously Update ScheduleEvents, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more schedule events.
-        /// </remarks>
-        /// <param name="scheduleEvents">
-        /// The set of <see cref="ScheduleEvent"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<ScheduleEvent>, ResultsMeta)> UpdateScheduleEventsAsync(
-            IEnumerable<ScheduleEvent> scheduleEvents,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update ScheduleEvents.
@@ -6628,25 +6592,45 @@ namespace Intuit.TSheets.Api
             ScheduleEvent scheduleEvent,
             CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Asynchronously Update ScheduleEvents.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<ScheduleEvent>, ResultsMeta)> UpdateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents);
+
+        /// <summary>
+        /// Asynchronously Update ScheduleEvents, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more schedule events.
+        /// </remarks>
+        /// <param name="scheduleEvents">
+        /// The set of <see cref="ScheduleEvent"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="ScheduleEvent"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<ScheduleEvent>, ResultsMeta)> UpdateScheduleEventsAsync(
+            IEnumerable<ScheduleEvent> scheduleEvents,
+            CancellationToken cancellationToken);
+
         #endregion
 
         #region Timesheets 
-
-        /// <summary>
-        /// Create Timesheets.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more timesheets to your company.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Timesheet"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Timesheet>, ResultsMeta) CreateTimesheets(
-            IEnumerable<Timesheet> timesheets);
 
         /// <summary>
         /// Create Timesheets.
@@ -6665,7 +6649,7 @@ namespace Intuit.TSheets.Api
             Timesheet timesheet);
 
         /// <summary>
-        /// Asynchronously Create Timesheets.
+        /// Create Timesheets.
         /// </summary>
         /// <remarks>
         /// Add one or more timesheets to your company.
@@ -6677,28 +6661,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="Timesheet"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
+        (IList<Timesheet>, ResultsMeta) CreateTimesheets(
             IEnumerable<Timesheet> timesheets);
-
-        /// <summary>
-        /// Asynchronously Create Timesheets, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more timesheets to your company.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Timesheet"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
-            IEnumerable<Timesheet> timesheets,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Timesheets.
@@ -6734,6 +6698,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(Timesheet, ResultsMeta)> CreateTimesheetAsync(
             Timesheet timesheet,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more timesheets to your company.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Timesheet"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets);
+
+        /// <summary>
+        /// Asynchronously Create Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more timesheets to your company.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Timesheet"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<Timesheet>, ResultsMeta)> CreateTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -6862,22 +6862,6 @@ namespace Intuit.TSheets.Api
         /// Update Timesheets.
         /// </summary>
         /// <remarks>
-        /// Edit one or more timesheets in your company.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="Timesheet"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<Timesheet>, ResultsMeta) UpdateTimesheets(
-            IEnumerable<Timesheet> timesheets);
-
-        /// <summary>
-        /// Update Timesheets.
-        /// </summary>
-        /// <remarks>
         /// Edit a single timesheet in your company.
         /// </remarks>
         /// <param name="timesheet">
@@ -6889,6 +6873,22 @@ namespace Intuit.TSheets.Api
         /// </returns>
         (Timesheet, ResultsMeta) UpdateTimesheet(
             Timesheet timesheet);
+
+        /// <summary>
+        /// Update Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more timesheets in your company.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="Timesheet"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        (IList<Timesheet>, ResultsMeta) UpdateTimesheets(
+            IEnumerable<Timesheet> timesheets);
 
         /// <summary>
         /// Asynchronously Update Timesheets.
@@ -6905,6 +6905,26 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(IList<Timesheet>, ResultsMeta)> UpdateTimesheetsAsync(
             IEnumerable<Timesheet> timesheets);
+
+        /// <summary>
+        /// Asynchronously Update Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit a single timesheet in your company.
+        /// </remarks>
+        /// <param name="timesheet">
+        /// The <see cref="Timesheet"/> object to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Timesheet"/> object that was updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(Timesheet, ResultsMeta)> UpdateTimesheetAsync(
+            Timesheet timesheet,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Timesheets, with support for cancellation.
@@ -6943,26 +6963,6 @@ namespace Intuit.TSheets.Api
             Timesheet timesheet);
 
         /// <summary>
-        /// Asynchronously Update Timesheets, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit a single timesheet in your company.
-        /// </remarks>
-        /// <param name="timesheet">
-        /// The <see cref="Timesheet"/> object to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The <see cref="Timesheet"/> object that was updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(Timesheet, ResultsMeta)> UpdateTimesheetAsync(
-            Timesheet timesheet,
-            CancellationToken cancellationToken);
-
-        /// <summary>
         /// Delete Timesheets.
         /// </summary>
         /// <remarks>
@@ -6978,18 +6978,6 @@ namespace Intuit.TSheets.Api
         /// Delete Timesheets.
         /// </summary>
         /// <remarks>
-        /// Delete one or more <see cref="Timesheet"/> objects.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be deleted.
-        /// </param>
-        void DeleteTimesheets(
-            IEnumerable<Timesheet> timesheets);
-
-        /// <summary>
-        /// Delete Timesheets.
-        /// </summary>
-        /// <remarks>
         /// Delete a single <see cref="Timesheet"/> object, by id.
         /// </remarks>
         /// <param name="id">
@@ -6997,6 +6985,18 @@ namespace Intuit.TSheets.Api
         /// </param>
         void DeleteTimesheet(
             int id);
+
+        /// <summary>
+        /// Delete Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Timesheet"/> objects.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be deleted.
+        /// </param>
+        void DeleteTimesheets(
+            IEnumerable<Timesheet> timesheets);
 
         /// <summary>
         /// Delete Timesheets.
@@ -7044,36 +7044,6 @@ namespace Intuit.TSheets.Api
         /// Asynchronously Delete Timesheets.
         /// </summary>
         /// <remarks>
-        /// Delete one or more <see cref="Timesheet"/> objects.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be deleted.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        Task DeleteTimesheetsAsync(
-            IEnumerable<Timesheet> timesheets);
-
-        /// <summary>
-        /// Asynchronously Delete Timesheets, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Delete one or more <see cref="Timesheet"/> objects.
-        /// </remarks>
-        /// <param name="timesheets">
-        /// The set of <see cref="Timesheet"/> objects to be deleted.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        Task DeleteTimesheetsAsync(
-            IEnumerable<Timesheet> timesheets,
-            CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Asynchronously Delete Timesheets.
-        /// </summary>
-        /// <remarks>
         /// Delete a single <see cref="Timesheet"/> object, by id.
         /// </remarks>
         /// <param name="id">
@@ -7098,6 +7068,36 @@ namespace Intuit.TSheets.Api
         /// <returns>The asynchronous task.</returns>
         Task DeleteTimesheetAsync(
             int id,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Timesheet"/> objects.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be deleted.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets);
+
+        /// <summary>
+        /// Asynchronously Delete Timesheets, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Delete one or more <see cref="Timesheet"/> objects.
+        /// </remarks>
+        /// <param name="timesheets">
+        /// The set of <see cref="Timesheet"/> objects to be deleted.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
+        Task DeleteTimesheetsAsync(
+            IEnumerable<Timesheet> timesheets,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -7264,22 +7264,6 @@ namespace Intuit.TSheets.Api
         /// Create Users.
         /// </summary>
         /// <remarks>
-        /// Add one or more users to your company.
-        /// </remarks>
-        /// <param name="users">
-        /// The set of <see cref="User"/> objects to be created.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="User"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<User>, ResultsMeta) CreateUsers(
-            IEnumerable<User> users);
-
-        /// <summary>
-        /// Create Users.
-        /// </summary>
-        /// <remarks>
         /// Add a single user to your company.
         /// </remarks>
         /// <param name="user">
@@ -7293,7 +7277,7 @@ namespace Intuit.TSheets.Api
             User user);
 
         /// <summary>
-        /// Asynchronously Create Users.
+        /// Create Users.
         /// </summary>
         /// <remarks>
         /// Add one or more users to your company.
@@ -7305,28 +7289,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="User"/> objects that were created, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
+        (IList<User>, ResultsMeta) CreateUsers(
             IEnumerable<User> users);
-
-        /// <summary>
-        /// Asynchronously Create Users, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Add one or more users to your company.
-        /// </remarks>
-        /// <param name="users">
-        /// The set of <see cref="User"/> objects to be created.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="User"/> objects that were created, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
-            IEnumerable<User> users,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Create Users.
@@ -7362,6 +7326,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(User, ResultsMeta)> CreateUserAsync(
             User user,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Create Users.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more users to your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be created.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
+            IEnumerable<User> users);
+
+        /// <summary>
+        /// Asynchronously Create Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Add one or more users to your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be created.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were created, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<User>, ResultsMeta)> CreateUsersAsync(
+            IEnumerable<User> users,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -7588,22 +7588,6 @@ namespace Intuit.TSheets.Api
         /// Update Users.
         /// </summary>
         /// <remarks>
-        /// Edit one or more users in your company.
-        /// </remarks>
-        /// <param name="users">
-        /// The set of <see cref="User"/> objects to be updated.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="User"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        (IList<User>, ResultsMeta) UpdateUsers(
-            IEnumerable<User> users);
-
-        /// <summary>
-        /// Update Users.
-        /// </summary>
-        /// <remarks>
         /// Edit a single user in your company.
         /// </remarks>
         /// <param name="user">
@@ -7617,7 +7601,7 @@ namespace Intuit.TSheets.Api
             User user);
 
         /// <summary>
-        /// Asynchronously Update Users.
+        /// Update Users.
         /// </summary>
         /// <remarks>
         /// Edit one or more users in your company.
@@ -7629,28 +7613,8 @@ namespace Intuit.TSheets.Api
         /// The set of the <see cref="User"/> objects that were updated, along with
         /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
         /// </returns>
-        Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
+        (IList<User>, ResultsMeta) UpdateUsers(
             IEnumerable<User> users);
-
-        /// <summary>
-        /// Asynchronously Update Users, with support for cancellation.
-        /// </summary>
-        /// <remarks>
-        /// Edit one or more users in your company.
-        /// </remarks>
-        /// <param name="users">
-        /// The set of <see cref="User"/> objects to be updated.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
-        /// </param>
-        /// <returns>
-        /// The set of the <see cref="User"/> objects that were updated, along with
-        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
-        /// </returns>
-        Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
-            IEnumerable<User> users,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously Update Users.
@@ -7686,6 +7650,42 @@ namespace Intuit.TSheets.Api
         /// </returns>
         Task<(User, ResultsMeta)> UpdateUserAsync(
             User user,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously Update Users.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more users in your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be updated.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
+            IEnumerable<User> users);
+
+        /// <summary>
+        /// Asynchronously Update Users, with support for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// Edit one or more users in your company.
+        /// </remarks>
+        /// <param name="users">
+        /// The set of <see cref="User"/> objects to be updated.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// <returns>
+        /// The set of the <see cref="User"/> objects that were updated, along with
+        /// an output instance of the <see cref="ResultsMeta"/> class containing additional data.
+        /// </returns>
+        Task<(IList<User>, ResultsMeta)> UpdateUsersAsync(
+            IEnumerable<User> users,
             CancellationToken cancellationToken);
 
         #endregion

--- a/Intuit.TSheets/Client/Core/IRestClient.cs
+++ b/Intuit.TSheets/Client/Core/IRestClient.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Client.Core
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Utilities;
 
@@ -34,8 +35,15 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="jsonData">The content to be sent in the body of the request.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The serialized response of the API method call.</returns>
-        Task<string> CreateAsync(EndpointName endpointName, string jsonData, LogContext logContext);
+        Task<string> CreateAsync(
+            EndpointName endpointName,
+            string jsonData,
+            LogContext logContext,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves entities from TSheets via an HTTP GET call to the API endpoint.
@@ -43,8 +51,15 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="filters">The key-value pairs to be sent as URL request parameters.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The serialized response of the API method call.</returns>
-        Task<string> GetAsync(EndpointName endpointName, Dictionary<string, string> filters, LogContext logContext);
+        Task<string> GetAsync(
+            EndpointName endpointName,
+            Dictionary<string, string> filters,
+            LogContext logContext,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Downloads binary data from TSheets via an HTTP POST call to the API endpoint.
@@ -52,8 +67,15 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="filters">The key-value pairs to be sent as URL request parameters.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The serialized response of the API method call.</returns>
-        Task<byte[]> DownloadAsync(EndpointName endpointName, Dictionary<string, string> filters, LogContext logContext);
+        Task<byte[]> DownloadAsync(
+            EndpointName endpointName,
+            Dictionary<string, string> filters,
+            LogContext logContext,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Updates entities in TSheets via an HTTP PUT call to the API endpoint.
@@ -61,8 +83,15 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="jsonData">The content to be sent in the body of the request.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The serialized response of the API method call.</returns>
-        Task<string> UpdateAsync(EndpointName endpointName, string jsonData, LogContext logContext);
+        Task<string> UpdateAsync(
+            EndpointName endpointName,
+            string jsonData,
+            LogContext logContext,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Removes entities in TSheets via an HTTP DELETE call to the API endpoint.
@@ -70,7 +99,14 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="ids">The ids of the entities to be deleted.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The serialized response of the API method call.</returns>
-        Task<string> DeleteAsync(EndpointName endpointName, IEnumerable<int> ids, LogContext logContext);
+        Task<string> DeleteAsync(
+            EndpointName endpointName,
+            IEnumerable<int> ids,
+            LogContext logContext,
+            CancellationToken cancellationToken);
     }
 }

--- a/Intuit.TSheets/Client/Core/ResilientRestClient.cs
+++ b/Intuit.TSheets/Client/Core/ResilientRestClient.cs
@@ -25,7 +25,6 @@ namespace Intuit.TSheets.Client.Core
     using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
-    using Intuit.TSheets.Client.Extensions;
     using Intuit.TSheets.Client.Utilities;
     using Intuit.TSheets.Model.Exceptions;
     using Microsoft.Extensions.Logging;

--- a/Intuit.TSheets/Client/Core/ResilientRestClient.cs
+++ b/Intuit.TSheets/Client/Core/ResilientRestClient.cs
@@ -22,6 +22,7 @@ namespace Intuit.TSheets.Client.Core
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
     using Intuit.TSheets.Client.Extensions;
@@ -96,18 +97,21 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="jsonData">The content to be sent in the body of the request.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The serialized response of the API method call.</returns>
         public async Task<string> CreateAsync(
             EndpointName endpointName,
             string jsonData,
-            LogContext logContext)
+            LogContext logContext,
+            CancellationToken cancellationToken)
         {
             return await ExecutePolicyAsync(
                 logContext,
                 () => this.restClient.CreateAsync(
                     endpointName,
                     jsonData,
-                    logContext)).ConfigureAwait(false);
+                    logContext,
+                    cancellationToken)).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -116,18 +120,21 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="filters">The key-value pairs to be sent as URL request parameters.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The serialized response of the API method call.</returns>
         public async Task<string> GetAsync(
             EndpointName endpointName,
             Dictionary<string, string> filters,
-            LogContext logContext)
+            LogContext logContext,
+            CancellationToken cancellationToken)
         {
             return await ExecutePolicyAsync(
                 logContext,
                 () => this.restClient.GetAsync(
                     endpointName,
                     filters,
-                    logContext)).ConfigureAwait(false);
+                    logContext,
+                    cancellationToken)).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -136,15 +143,17 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="filters">The key-value pairs to be sent as URL request parameters.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The serialized response of the API method call.</returns>
         public async Task<byte[]> DownloadAsync(
             EndpointName endpointName,
             Dictionary<string, string> filters,
-            LogContext logContext)
+            LogContext logContext,
+            CancellationToken cancellationToken)
         {
             return await ExecutePolicyAsync(
                     logContext,
-                    () => this.restClient.DownloadAsync(endpointName, filters, logContext))
+                    () => this.restClient.DownloadAsync(endpointName, filters, logContext, cancellationToken))
                 .ConfigureAwait(false);
         }
 
@@ -154,15 +163,17 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="jsonData">The content to be sent in the body of the request.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The serialized response of the API method call.</returns>
         public async Task<string> UpdateAsync(
             EndpointName endpointName,
             string jsonData,
-            LogContext logContext)
+            LogContext logContext,
+            CancellationToken cancellationToken)
         {
             return await ExecutePolicyAsync(
                     logContext,
-                    () => this.restClient.UpdateAsync(endpointName, jsonData, logContext))
+                    () => this.restClient.UpdateAsync(endpointName, jsonData, logContext, cancellationToken))
                 .ConfigureAwait(false);
         }
 
@@ -172,15 +183,17 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="ids">The ids of the entities to be deleted.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The serialized response of the API method call.</returns>
         public async Task<string> DeleteAsync(
             EndpointName endpointName,
             IEnumerable<int> ids,
-            LogContext logContext)
+            LogContext logContext,
+            CancellationToken cancellationToken)
         {
             return await ExecutePolicyAsync(
                     logContext,
-                    () => this.restClient.DeleteAsync(endpointName, ids, logContext))
+                    () => this.restClient.DeleteAsync(endpointName, ids, logContext, cancellationToken))
                 .ConfigureAwait(false);
         }
 

--- a/Intuit.TSheets/Client/Core/RestClient.cs
+++ b/Intuit.TSheets/Client/Core/RestClient.cs
@@ -24,6 +24,7 @@ namespace Intuit.TSheets.Client.Core
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
     using Intuit.TSheets.Client.Extensions;
@@ -72,7 +73,10 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="logger">
         /// Logging provider, an instance of <see cref="ILogger"/>.
         /// </param>
-        internal RestClient(DataServiceContext context, HttpClient httpClient, ILogger logger)
+        internal RestClient(
+            DataServiceContext context,
+            HttpClient httpClient,
+            ILogger logger)
         {
             this.context = context;
             this.logger = logger;
@@ -107,18 +111,20 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="requestData">The content to be sent in the body of the request.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The serialized response of the API method call.</returns>
         public async Task<string> CreateAsync(
             EndpointName endpointName,
             string requestData,
-            LogContext logContext)
+            LogContext logContext,
+            CancellationToken cancellationToken)
         {
             Uri requestUri = CreateRequestUri(endpointName);
 
             LogMethodCall(MethodType.Post, requestUri, logContext, requestData);
 
             HttpContent content = new StringContent(requestData, Encoding.UTF8);
-            HttpResponseMessage response = await this.httpClient.PostAsync(requestUri, content).ConfigureAwait(false);
+            HttpResponseMessage response = await this.httpClient.PostAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
 
             return ProcessResponse(response, logContext, MethodType.Post);
         }
@@ -129,14 +135,19 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="filters">The key-value pairs to be sent as URL request parameters.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The serialized response of the API method call.</returns>
-        public async Task<string> GetAsync(EndpointName endpointName, Dictionary<string, string> filters, LogContext logContext)
+        public async Task<string> GetAsync(
+            EndpointName endpointName,
+            Dictionary<string, string> filters,
+            LogContext logContext,
+            CancellationToken cancellationToken)
         {
             Uri requestUri = CreateRequestUri(endpointName, filters);
 
             LogMethodCall(MethodType.Get, requestUri, logContext);
 
-            HttpResponseMessage response = await this.httpClient.GetAsync(requestUri).ConfigureAwait(false);
+            HttpResponseMessage response = await this.httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
 
             return ProcessResponse(response, logContext, MethodType.Get);
         }
@@ -147,15 +158,20 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="requestData">The content to be sent in the body of the request.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The serialized response of the API method call.</returns>
-        public async Task<string> UpdateAsync(EndpointName endpointName, string requestData, LogContext logContext)
+        public async Task<string> UpdateAsync(
+            EndpointName endpointName,
+            string requestData,
+            LogContext logContext,
+            CancellationToken cancellationToken)
         {
             Uri requestUri = CreateRequestUri(endpointName);
 
             LogMethodCall(MethodType.Put, requestUri, logContext, requestData);
 
             HttpContent content = new StringContent(requestData, Encoding.UTF8);
-            HttpResponseMessage response = await this.httpClient.PutAsync(requestUri, content).ConfigureAwait(false);
+            HttpResponseMessage response = await this.httpClient.PutAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
 
             return ProcessResponse(response, logContext, MethodType.Put);
         }
@@ -166,8 +182,13 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="ids">The ids of the entities to be deleted.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The serialized response of the API method call.</returns>
-        public async Task<string> DeleteAsync(EndpointName endpointName, IEnumerable<int> ids, LogContext logContext)
+        public async Task<string> DeleteAsync(
+            EndpointName endpointName,
+            IEnumerable<int> ids,
+            LogContext logContext,
+            CancellationToken cancellationToken)
         {
             var filter = new Dictionary<string, string>
             {
@@ -178,7 +199,7 @@ namespace Intuit.TSheets.Client.Core
 
             LogMethodCall(MethodType.Delete, requestUri, logContext);
 
-            HttpResponseMessage response = await this.httpClient.DeleteAsync(requestUri).ConfigureAwait(false);
+            HttpResponseMessage response = await this.httpClient.DeleteAsync(requestUri, cancellationToken).ConfigureAwait(false);
 
             return ProcessResponse(response, logContext, MethodType.Delete);
         }
@@ -189,17 +210,19 @@ namespace Intuit.TSheets.Client.Core
         /// <param name="endpointName">The name of the endpoint, <see cref="EndpointName"/></param>
         /// <param name="filters">The key-value pairs to be sent as URL request parameters.</param>
         /// <param name="logContext">Call-specific contextual information for logging purposes.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The serialized response of the API method call.</returns>
         public async Task<byte[]> DownloadAsync(
             EndpointName endpointName,
             Dictionary<string, string> filters,
-            LogContext logContext)
+            LogContext logContext,
+            CancellationToken cancellationToken)
         {
             Uri requestUri = CreateRequestUri(endpointName, filters);
 
             LogMethodCall(MethodType.Get, requestUri, logContext);
 
-            HttpResponseMessage response = await this.httpClient.GetAsync(requestUri).ConfigureAwait(false);
+            HttpResponseMessage response = await this.httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/CreateContextValidator.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/CreateContextValidator.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Intuit.TSheets.Model.Exceptions;
@@ -40,8 +41,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var createContext = (CreateContext<T>)context;
 

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/CreateRequestSerializer.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/CreateRequestSerializer.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Intuit.TSheets.Client.Serialization.Attributes;
@@ -49,8 +50,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var createContext = (CreateContext<T>)context;
 

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/DeleteContextValidator.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/DeleteContextValidator.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Intuit.TSheets.Model.Exceptions;
@@ -40,8 +41,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var deleteContext = (DeleteContext<T>)context;
 

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/DeleteResultsDeserializer.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/DeleteResultsDeserializer.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
     using Intuit.TSheets.Client.Extensions;
@@ -44,8 +45,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             JObject document = JObject.Parse(context.ResponseContent);
             IEnumerable<JToken> tokens = document.SelectTokens(context.JsonPath());

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/GetReportDeserializer.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/GetReportDeserializer.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Microsoft.Extensions.Logging;
@@ -40,8 +41,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of report.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var reportContext = (GetReportContext<T>)context;
             var report = JsonConvert.DeserializeObject<Report<T>>(context.ResponseContent);

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/GetReportSerializer.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/GetReportSerializer.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Intuit.TSheets.Client.Serialization.Attributes;
@@ -41,7 +42,7 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// </summary>
         private static JsonConverter SerializationConverter =>
             new SerializationConverter(typeof(NoSerializeOnCreateAttribute), typeof(NoSerializeOnWriteAttribute));
-               
+
         /// <summary>
         /// Reads from the context object the filter which specifies how the report should be retrieved, and writes
         /// it back to the context as a serialized JSON string, in the format expected by the TSheets API.
@@ -49,8 +50,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var getReportContext = (GetReportContext<T>)context;
 

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/GetResultsDeserializer.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/GetResultsDeserializer.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Extensions;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -43,8 +44,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             JObject document = JObject.Parse(context.ResponseContent);
             IEnumerable<JToken> tokens = document.SelectTokens(context.JsonPath());

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/GetResultsMetaDeserializer.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/GetResultsMetaDeserializer.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Microsoft.Extensions.Logging;
@@ -42,8 +43,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             try
             {

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/IPipelineElement.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/IPipelineElement.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Microsoft.Extensions.Logging;
@@ -34,7 +35,10 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">An instance of a logging object.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The asynchronous Task.</returns>
-        Task ProcessAsync<T>(PipelineContext<T> context, ILogger logger);
+        Task ProcessAsync<T>(PipelineContext<T> context, ILogger logger, CancellationToken cancellationToken);
     }
 }

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/ModificationResultsDeserializer.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/ModificationResultsDeserializer.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
     using Intuit.TSheets.Client.Extensions;
@@ -45,8 +46,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             JToken document = JToken.Parse(context.ResponseContent);
             IEnumerable<JToken> tokens = document.SelectTokens(context.JsonPath());
@@ -61,7 +68,7 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
                 // If not success, we may not be able to deserialize the entity, but we'll try anyway.
                 // It's not a problem if serialization fails here, as a later pipeline stage will still
                 // be able to retrieve the error status codes and descriptions.
-                T entity = default(T);
+                T entity = default;
                 try
                 {
                     entity = JsonConvert.DeserializeObject<T>(token.ToString());

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/MultiStatusHandler.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/MultiStatusHandler.cs
@@ -22,6 +22,7 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -47,8 +48,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             if (context.Results == null || !context.Results.ErrorItems.Any())
             {

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/PipelineElement.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/PipelineElement.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Intuit.TSheets.Client.Utilities;
@@ -53,8 +54,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The asynchronous task.</returns>
-        public virtual async Task ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        public virtual async Task ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -66,7 +73,7 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
                     nameof(ProcessAsync));
 
                 // Call the derived class' overridden method to perform the "real" work.
-                await _ProcessAsync(context, logger).ConfigureAwait(false);
+                await _ProcessAsync(context, logger, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -115,7 +122,13 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of the data entity.</typeparam>
         /// <param name="context">Contextual information for the request.</param>
         /// <param name="log">The logger.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The asynchronous task.</returns>
-        protected abstract Task _ProcessAsync<T>(PipelineContext<T> context, ILogger log);
+        protected abstract Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger log,
+            CancellationToken cancellationToken);
     }
 }

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientDeleteHandler.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientDeleteHandler.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Microsoft.Extensions.Logging;
@@ -39,12 +40,22 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The asynchronous task.</returns>
-        protected override async Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override async Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             IEnumerable<int> ids = ((DeleteContext<T>)context).Ids;
 
-            context.ResponseContent = await context.RestClient.DeleteAsync(context.Endpoint, ids, context.LogContext).ConfigureAwait(false);
+            context.ResponseContent = await context.RestClient.DeleteAsync(
+                context.Endpoint,
+                ids,
+                context.LogContext,
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientDownloadHandler.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientDownloadHandler.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Microsoft.Extensions.Logging;
@@ -39,8 +40,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The asynchronous task.</returns>
-        protected override async Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override async Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var downloadContext = (DownloadContext<T>)context;
             Dictionary<string, string> filters = downloadContext.Filter.GetFilters();
@@ -48,7 +55,8 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
             downloadContext.RawResponseContent = await downloadContext.RestClient.DownloadAsync(
                 downloadContext.Endpoint,
                 filters,
-                downloadContext.LogContext).ConfigureAwait(false);
+                downloadContext.LogContext,
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientGetHandler.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientGetHandler.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.Extensions;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -40,8 +41,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The asynchronous task.</returns>
-        protected override async Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override async Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var getContext = (GetContext<T>)context;
             Dictionary<string, string> filters = getContext.Filter.GetFiltersWithOptions(getContext.Options);
@@ -49,7 +56,8 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
             getContext.ResponseContent = await getContext.RestClient.GetAsync(
                 getContext.Endpoint,
                 filters,
-                getContext.LogContext).ConfigureAwait(false);
+                getContext.LogContext,
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientPostHandler.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientPostHandler.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Microsoft.Extensions.Logging;
@@ -38,15 +39,22 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The asynchronous task.</returns>
-        protected override async Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override async Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             string serializedRequest = ((ISerializedRequest)context).SerializedRequest;
 
             context.ResponseContent = await context.RestClient.CreateAsync(
                 context.Endpoint,
                 serializedRequest,
-                context.LogContext).ConfigureAwait(false);
+                context.LogContext,
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientPutHandler.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientPutHandler.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Microsoft.Extensions.Logging;
@@ -39,14 +40,18 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
         /// <returns>The asynchronous task.</returns>
-        protected override async Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override async Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             string serializedRequest = ((ISerializedRequest)context).SerializedRequest;
 
             context.ResponseContent = await context.RestClient.UpdateAsync(
                 context.Endpoint,
                 serializedRequest,
-                context.LogContext).ConfigureAwait(false);
+                context.LogContext,
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/SupplementalDataDeserializer.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/SupplementalDataDeserializer.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Intuit.TSheets.Client.Utilities;
@@ -48,8 +49,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             JToken document = JToken.Parse(context.ResponseContent);
             JObject supplementalDataSection = (JObject)document.SelectToken(JsonPath);

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/UpdateContextValidator.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/UpdateContextValidator.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Intuit.TSheets.Model.Exceptions;
@@ -40,8 +41,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The contextual vehicle of state.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var updateContext = (UpdateContext<T>)context;
 

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/UpdateRequestSerializer.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/UpdateRequestSerializer.cs
@@ -19,6 +19,7 @@
 
 namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Intuit.TSheets.Client.Serialization.Attributes;
@@ -49,8 +50,14 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        protected override Task _ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        protected override Task _ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var updateContext = (UpdateContext<T>)context;
 

--- a/Intuit.TSheets/Client/RequestFlow/Pipelines/AutoBatchingPipeline.cs
+++ b/Intuit.TSheets/Client/RequestFlow/Pipelines/AutoBatchingPipeline.cs
@@ -79,7 +79,6 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
             CancellationToken cancellationToken)
         {
             var writeContext = (IWritableContext<T>)context;
-            string correlationId = context.LogContext.CorrelationId;
             string httpMethod = context.MethodType.ToString();
 
             var allResults = new Results<T>();

--- a/Intuit.TSheets/Client/RequestFlow/Pipelines/AutoBatchingPipeline.cs
+++ b/Intuit.TSheets/Client/RequestFlow/Pipelines/AutoBatchingPipeline.cs
@@ -22,6 +22,7 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
     using Intuit.TSheets.Client.Extensions;
@@ -68,8 +69,14 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
         /// <typeparam name="T">The type of data entity.</typeparam>
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>The completed asynchronous task.</returns>
-        public async Task ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        public async Task ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var writeContext = (IWritableContext<T>)context;
             string correlationId = context.LogContext.CorrelationId;
@@ -86,6 +93,8 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
                 int totalBatchCount = GetBatchCount(allItems.Count, MaxItemsPerBatch);
                 foreach (IEnumerable<T> batch in allItems.MakeBatchesOfSize(MaxItemsPerBatch))
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     T[] batchItems = batch.ToArray();
 
                     ++batchNumber;
@@ -102,7 +111,7 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
 
                     try
                     {
-                        await InnerPipeline.ProcessAsync(context, logger).ConfigureAwait(false);
+                        await InnerPipeline.ProcessAsync(context, logger, cancellationToken).ConfigureAwait(false);
                     }
                     catch (MultiStatusException<T> ex)
                     {
@@ -133,7 +142,7 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
             {
                 // There are few enough items that batching isn't needed.
                 // In this case, we can simply call the inner pipeline.
-                await InnerPipeline.ProcessAsync(context, logger).ConfigureAwait(false);
+                await InnerPipeline.ProcessAsync(context, logger, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/Intuit.TSheets/Client/RequestFlow/Pipelines/AutoPagingPipeline.cs
+++ b/Intuit.TSheets/Client/RequestFlow/Pipelines/AutoPagingPipeline.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Api;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
@@ -73,7 +74,10 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
         /// <returns>The completed asynchronous task.</returns>
-        public async Task ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        public async Task ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var getContext = (GetContext<T>)context;
             string correlationId = getContext.LogContext.CorrelationId;
@@ -81,6 +85,8 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
 
             do
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (getContext.Options.Page.HasValue)
                 {
                     logger?.LogInformation(
@@ -91,7 +97,7 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
                         getContext.Endpoint);
                 }
 
-                await InnerPipeline.ProcessAsync(getContext, logger).ConfigureAwait(false);
+                await InnerPipeline.ProcessAsync(getContext, logger, cancellationToken).ConfigureAwait(false);
                 consolidatedItems.AddRange(getContext.Results.Items);
 
                 if (getContext.ResultsMeta.More)

--- a/Intuit.TSheets/Client/RequestFlow/Pipelines/AutoPagingPipeline.cs
+++ b/Intuit.TSheets/Client/RequestFlow/Pipelines/AutoPagingPipeline.cs
@@ -80,7 +80,6 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
             CancellationToken cancellationToken)
         {
             var getContext = (GetContext<T>)context;
-            string correlationId = getContext.LogContext.CorrelationId;
             var consolidatedItems = new List<T>();
 
             do

--- a/Intuit.TSheets/Client/RequestFlow/Pipelines/RequestPipeline.cs
+++ b/Intuit.TSheets/Client/RequestFlow/Pipelines/RequestPipeline.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Client.RequestFlow.Pipelines
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Intuit.TSheets.Client.RequestFlow.Contexts;
     using Intuit.TSheets.Client.RequestFlow.PipelineElements;
@@ -61,11 +62,14 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
         /// <param name="context">The object of state through the pipeline.</param>
         /// <param name="logger">The logging instance.</param>
         /// <returns>The completed asynchronous task.</returns>
-        public async Task ProcessAsync<T>(PipelineContext<T> context, ILogger logger)
+        public async Task ProcessAsync<T>(
+            PipelineContext<T> context,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             foreach (IPipelineElement pipelineElement in PipelineElements)
             {
-                await pipelineElement.ProcessAsync(context, logger).ConfigureAwait(false);
+                await pipelineElement.ProcessAsync(context, logger, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/Intuit.TSheets/Client/RequestFlow/Pipelines/RequestPipeline.cs
+++ b/Intuit.TSheets/Client/RequestFlow/Pipelines/RequestPipeline.cs
@@ -1,4 +1,5 @@
-﻿// *******************************************************************************
+﻿
+// *******************************************************************************
 // <copyright file="RequestPipeline.cs" company="Intuit">
 // Copyright (c) 2019 Intuit
 //
@@ -69,6 +70,8 @@ namespace Intuit.TSheets.Client.RequestFlow.Pipelines
         {
             foreach (IPipelineElement pipelineElement in PipelineElements)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 await pipelineElement.ProcessAsync(context, logger, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/Intuit.TSheets/Client/Utilities/EntityTypeMapper.cs
+++ b/Intuit.TSheets/Client/Utilities/EntityTypeMapper.cs
@@ -35,6 +35,7 @@ namespace Intuit.TSheets.Client.Utilities
             { "customfields",     () => new CustomField() },
             { "customfielditems", () => new CustomFieldItem() },
             { "files",            () => new File() },
+            { "geofence_configs", () => new GeofenceConfig() },
             { "geolocations",     () => new Geolocation() },
             { "groups",           () => new Group() },
             { "jobcodes",         () => new Jobcode() },

--- a/Intuit.TSheets/Intuit.TSheets.csproj
+++ b/Intuit.TSheets/Intuit.TSheets.csproj
@@ -9,14 +9,14 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Intuit</Authors>
     <PackageProjectUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</PackageProjectUrl>
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
-    <FileVersion>1.1.2.0</FileVersion>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <PackageIcon>Circle_T_web128px.png</PackageIcon>
     <RepositoryType>Git</RepositoryType>
-    <PackageReleaseNotes>Bugfix: Fixing NuGet packaging Error NU5035 &amp; Warning NU5048, causing a build failure on VS2019.</PackageReleaseNotes>
+    <PackageReleaseNotes>Minor Feature: Adding CancellationToken support for all asynchronous API methods.</PackageReleaseNotes>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <Version>1.1.2</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Intuit.TSheets/Intuit.TSheets.csproj
+++ b/Intuit.TSheets/Intuit.TSheets.csproj
@@ -17,6 +17,7 @@
     <PackageReleaseNotes>Minor Feature: Adding CancellationToken support for all asynchronous API methods.</PackageReleaseNotes>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
     <Version>1.2.0</Version>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TSheets-V1-DotNET-SDK
 **Support:** [![Help](https://img.shields.io/badge/Support-TSheets%20Developer-blue.svg)](https://www.tsheets.com/contact-tsheets)<br/>
 **Documentation:** [![User Guide](https://img.shields.io/badge/User%20Guide-SDK%20Docs-blue.svg)](./Documentation/tsheets-sdk.md)<br/>
 **Continuous Integration:** [![Build Status](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)<br/>
-**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.1.2-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
+**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.2.0-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
 
 The TSheets .NET SDK provides class libraries for accessing the TSheets API quickly, easily, and with confidence.
 It supports .Net Standard 2.0, and .Net Framework 4.7.2.


### PR DESCRIPTION
### What Changed?
Added an override for all public async API methods on the DataService class to accept an additional parameter of type _CancellationToken_.

### Why?
Without it, there's not good way to cancel asynchronous tasks.  Requested by user in issue #6 

### What else might be impacted?
**Requires C# language version >= 7.1**
As part of this change, all API methods were refactored to no longer use parameters with default values (i.e. `RequestOptions requestOptions = null`).  Overrides were added to support all previous use cases, so there should be no impact to the end user.

## Checklist

- [X ] Documentation
- [X] Unit Tests
- [X] Added self to contributors
- [X] Added SemVer label
- [X] Ready to be merged