### PR TITLE
Issue #13: Error with DateTimeOffset serialization in ScheduleEvent o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.2.1 (Mon. Nov 11th, 2019)
+
+#### Bugfix
+
+ - Fixing issue #13: Error with DateTimeOffset in ScheduleEvent object.
+
 # v1.2.0 (Mon. Oct 21st, 2019)
 
 #### Minor Feature

--- a/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
+++ b/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
@@ -14,7 +14,7 @@
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
     <PackageReleaseNotes />
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <FileVersion>1.2.0.0</FileVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
+++ b/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
@@ -14,7 +14,7 @@
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
     <FileVersion>1.1.0.0</FileVersion>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
+++ b/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
     <FileVersion>1.2.0.0</FileVersion>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets/Intuit.TSheets.csproj
+++ b/Intuit.TSheets/Intuit.TSheets.csproj
@@ -14,9 +14,9 @@
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <PackageIcon>Circle_T_web128px.png</PackageIcon>
     <RepositoryType>Git</RepositoryType>
-    <PackageReleaseNotes>Minor Feature: Adding CancellationToken support for all asynchronous API methods.</PackageReleaseNotes>
+    <PackageReleaseNotes>Bugfix: Fixing invalid serialization of DateTimeOffset properties for the ScheduleEvent object.</PackageReleaseNotes>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets/Model/EffectiveSettingsSection.cs
+++ b/Intuit.TSheets/Model/EffectiveSettingsSection.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Model
 {
     using System;
     using System.Collections.Generic;
+    using Intuit.TSheets.Client.Serialization.Attributes;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -38,6 +39,7 @@ namespace Intuit.TSheets.Model
         /// <summary>
         /// Gets the date/time at which the setting was most recently modified.
         /// </summary>
+        [NoSerializeOnWrite]
         [JsonProperty("last_modified")]
         public DateTimeOffset? LastModified { get; internal set; }
     }

--- a/Intuit.TSheets/Model/Filters/GeolocationFilter.cs
+++ b/Intuit.TSheets/Model/Filters/GeolocationFilter.cs
@@ -78,6 +78,7 @@ namespace Intuit.TSheets.Model.Filters
         /// <summary>
         /// Gets or sets the filter for returning only those geolocations modified before this date/time.
         /// </summary>
+        [JsonConverter(typeof(DateTimeFormatConverter))]
         [JsonProperty("modified_before")]
         public DateTimeOffset? ModifiedBefore { get; set; }
 

--- a/Intuit.TSheets/Model/Filters/ScheduleEventFilter.cs
+++ b/Intuit.TSheets/Model/Filters/ScheduleEventFilter.cs
@@ -131,12 +131,14 @@ namespace Intuit.TSheets.Model.Filters
         /// <summary>
         /// Gets or sets the value for filtering schedule events to a date range start.
         /// </summary>
+        [JsonConverter(typeof(DateTimeFormatConverter))]
         [JsonProperty("start")]
         public DateTimeOffset? Start { get; set; }
 
         /// <summary>
         /// Gets or sets the value for filtering schedule events to a date range end.
         /// </summary>
+        [JsonConverter(typeof(DateTimeFormatConverter))]
         [JsonProperty("end")]
         public DateTimeOffset? End { get; set; }
 

--- a/Intuit.TSheets/Model/Geolocation.cs
+++ b/Intuit.TSheets/Model/Geolocation.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Model
 {
     using System;
     using Intuit.TSheets.Client.Serialization.Attributes;
+    using Intuit.TSheets.Client.Serialization.Converters;
     using Intuit.TSheets.Model.Enums;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
@@ -134,6 +135,7 @@ namespace Intuit.TSheets.Model
         /// <summary>
         /// Gets or sets the date/time when this geolocation was created.
         /// </summary>
+        [JsonConverter(typeof(DateTimeFormatConverter))]
         [JsonProperty("created")]
         public DateTimeOffset? Created { get; set; }
     }

--- a/Intuit.TSheets/Model/Notification.cs
+++ b/Intuit.TSheets/Model/Notification.cs
@@ -21,6 +21,7 @@ namespace Intuit.TSheets.Model
 {
     using System;
     using Intuit.TSheets.Client.Serialization.Attributes;
+    using Intuit.TSheets.Client.Serialization.Converters;
     using Intuit.TSheets.Model.Enums;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
@@ -119,6 +120,7 @@ namespace Intuit.TSheets.Model
         /// <remarks>
         /// Defaults to the current time.
         /// </remarks>
+        [JsonConverter(typeof(DateTimeFormatConverter))]
         [JsonProperty("delivery_time")]
         public DateTimeOffset? DeliveryTime { get; set; }
 

--- a/Intuit.TSheets/Model/ScheduleEvent.cs
+++ b/Intuit.TSheets/Model/ScheduleEvent.cs
@@ -22,6 +22,7 @@ namespace Intuit.TSheets.Model
     using System;
     using System.Collections.Generic;
     using Intuit.TSheets.Client.Serialization.Attributes;
+    using Intuit.TSheets.Client.Serialization.Converters;
     using Intuit.TSheets.Model.Enums;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
@@ -84,12 +85,14 @@ namespace Intuit.TSheets.Model
         /// <summary>
         /// Gets or sets the date/time that represents the start time of this schedule event.
         /// </summary>
+        [JsonConverter(typeof(DateTimeFormatConverter))]
         [JsonProperty("start")]
         public DateTimeOffset? Start { get; set; }
 
         /// <summary>
         /// Gets or sets the date/time that represents the end time of this schedule event.
         /// </summary>
+        [JsonConverter(typeof(DateTimeFormatConverter))]
         [JsonProperty("end")]
         public DateTimeOffset? End { get; set; }
 
@@ -132,6 +135,7 @@ namespace Intuit.TSheets.Model
         /// Empty if the event is unassigned. Changing the assigned user IDs of
         /// an event may result in multiple event modifications.
         /// </remarks>
+        [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonProperty("assigned_user_ids")]
         public IList<int> AssignedUserIds { get; set; }
 

--- a/Intuit.TSheets/Model/Schemas/ScheduleEvent.xsd
+++ b/Intuit.TSheets/Model/Schemas/ScheduleEvent.xsd
@@ -52,11 +52,7 @@
       "type": "boolean"
     },
     "assigned_user_ids": {
-      "type": "array",
-      "items": {
-        "type": "integer",
-        "format": "int32"
-      }
+      "type": "string"
     },
     "jobcode_id": {
       "type": "integer",

--- a/Intuit.TSheets/Model/TimesheetsDeleted.cs
+++ b/Intuit.TSheets/Model/TimesheetsDeleted.cs
@@ -55,12 +55,14 @@ namespace Intuit.TSheets.Model
         /// <summary>
         /// Gets the date/time that represents the start time of this timesheet.
         /// </summary>
+        [JsonConverter(typeof(DateTimeFormatConverter))]
         [JsonProperty("start")]
         public DateTimeOffset? Start { get; internal set; }
 
         /// <summary>
         /// Gets the date/time that represents the end time of this timesheet.
         /// </summary>
+        [JsonConverter(typeof(DateTimeFormatConverter))]
         [JsonProperty("end")]
         public DateTimeOffset? End { get; internal set; }
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TSheets-V1-DotNET-SDK
 **Support:** [![Help](https://img.shields.io/badge/Support-TSheets%20Developer-blue.svg)](https://www.tsheets.com/contact-tsheets)<br/>
 **Documentation:** [![User Guide](https://img.shields.io/badge/User%20Guide-SDK%20Docs-blue.svg)](./Documentation/tsheets-sdk.md)<br/>
 **Continuous Integration:** [![Build Status](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)<br/>
-**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.2.0-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
+**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.2.1-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
 
 The TSheets .NET SDK provides class libraries for accessing the TSheets API quickly, easily, and with confidence.
 It supports .Net Standard 2.0, and .Net Framework 4.7.2.


### PR DESCRIPTION
…bject. Added missing JsonConverter attributes (to a few other objects as well).

### What Changed?
Added custom converter attributes to correctly serialize DateTimeOffset.

### Why?
The default serialization of a DateTimeOffset property results in a string format that is not allowed by the API (specifically the fractional seconds part).  By adding the JsonConverter attributes to the _start_ and _end_ properties, we will now use the custom converter which correctly handles this.

### What else might be impacted?
The attribute was missing on a few other models as well, and has been added.

## Checklist

- [] Documentation
- [ ] Unit Tests
- [ ] Added self to contributors
- [ ] Added SemVer label
- [ ] Ready to be mergd