### PR TITLE
v1.3.1 Fixing issue #17: Unhandled exception in GetDateTimeOffsetValu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.3.1 (Thurs. Mar. 19th, 2020)
+
+#### Bugfix
+
+ - Fixing issue #17: Unhandled exception on GetDateTimeOffsetValue
+
 # v1.3.0 (Fri. Jan 3rd, 2020)
 
 #### Feature

--- a/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
+++ b/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
@@ -13,9 +13,9 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
     <PackageReleaseNotes />
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <Version>1.3.0</Version>
-    <FileVersion>1.3.0.0</FileVersion>
+    <AssemblyVersion>1.3.1.0</AssemblyVersion>
+    <Version>1.3.1</Version>
+    <FileVersion>1.3.1.0</FileVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
+++ b/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
@@ -14,7 +14,7 @@
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
     <FileVersion>1.1.0.0</FileVersion>
-    <Version>1.2.1</Version>
+    <Version>1.3.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
+++ b/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
-    <Version>1.3.0</Version>
+    <AssemblyVersion>1.3.1.0</AssemblyVersion>
+    <FileVersion>1.3.1.0</FileVersion>
+    <Version>1.3.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets.Tests/Unit/Client/Serialization/Converters/DateFormatConverterTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/Serialization/Converters/DateFormatConverterTests.cs
@@ -70,6 +70,14 @@ namespace Intuit.TSheets.Tests.Unit.Client.Serialization.Converters
 
             Assert.AreEqual(DateTimeOffset.MinValue, testEntity.Created);
         }
+
+        [TestMethod, TestCategory("Unit")]
+        public void DateFormatConverter_DeserializesToDateTimeOffsetMinValueWhenEmptyString()
+        {
+            var testEntity = JsonConvert.DeserializeObject<DateFormatConverterTestEntity>("{\"Created\":\"\"}");
+
+            Assert.AreEqual(DateTimeOffset.MinValue, testEntity.Created);
+        }
     }
 
     public class DateFormatConverterTestEntity

--- a/Intuit.TSheets/Client/Serialization/Converters/DateFormatConverter.cs
+++ b/Intuit.TSheets/Client/Serialization/Converters/DateFormatConverter.cs
@@ -75,7 +75,7 @@ namespace Intuit.TSheets.Client.Serialization.Converters
 
         private static DateTimeOffset GetDateTimeOffsetValue(string stringValue, string format)
         {
-            return stringValue.Equals(UninitializedDateString)
+            return (stringValue.Equals(string.Empty) || stringValue.Equals(UninitializedDateString))
                 ? DateTimeOffset.MinValue
                 : DateTimeOffset.ParseExact(stringValue, format, CultureInfo.InvariantCulture);
         }

--- a/Intuit.TSheets/Intuit.TSheets.csproj
+++ b/Intuit.TSheets/Intuit.TSheets.csproj
@@ -9,14 +9,14 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Intuit</Authors>
     <PackageProjectUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</PackageProjectUrl>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.3.0.0</FileVersion>
+    <AssemblyVersion>1.3.1.0</AssemblyVersion>
+    <FileVersion>1.3.1.0</FileVersion>
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <PackageIcon>Circle_T_web128px.png</PackageIcon>
     <RepositoryType>Git</RepositoryType>
-    <PackageReleaseNotes>New Feature: Added Create and Update support for Custom Field objects.</PackageReleaseNotes>
+    <PackageReleaseNotes>Bugfix: addressing unhandled exception on GetDateTimeOffsetValue (https://github.com/intuit/TSheets-V1-DotNET-SDK/issues/17)</PackageReleaseNotes>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TSheets-V1-DotNET-SDK
 **Support:** [![Help](https://img.shields.io/badge/Support-TSheets%20Developer-blue.svg)](https://www.tsheets.com/contact-tsheets)<br/>
 **Documentation:** [![User Guide](https://img.shields.io/badge/User%20Guide-SDK%20Docs-blue.svg)](./Documentation/tsheets-sdk.md)<br/>
 **Continuous Integration:** [![Build Status](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)<br/>
-**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.3.0-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
+**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.3.1-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
 
 The TSheets .NET SDK provides class libraries for accessing the TSheets API quickly, easily, and with confidence.
 It supports .Net Standard 2.0, and .Net Framework 4.7.2.


### PR DESCRIPTION
…e due to an empty string not being able to be parsed

### What Changed?
Add check for empty string in Json converter when deserializing into DateTimeOffset.

### Why?
An employee with no previously submitted time or approved time will return empty strings in the following fields.  This leads to an unhandled exception when the converter tries to parse the string.

### What else might be impacted?
N/A

## Checklist

- [ NA] Documentation
- [ X] Unit Tests
- [ NA] Added self to contributors
- [ X] Added SemVer label
- [ X] Ready to be merged