### PR TITLE
Added support for connect_with_quickbooks jobcode property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.4.0 (Wed. Jan 13, 2021)
+
+#### Feature
+
+- Added `connectWithQuickBooks` property to `Jobcode` to support the two-way sync feature.
+
 # v1.3.2 (Tues. Jun. 9th, 2020)
 
 #### Bugfix

--- a/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
+++ b/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
@@ -13,9 +13,9 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
     <PackageReleaseNotes />
-    <AssemblyVersion>1.3.2.0</AssemblyVersion>
-    <Version>1.3.2</Version>
-    <FileVersion>1.3.2.0</FileVersion>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <Version>1.4.0</Version>
+    <FileVersion>1.4.0.0</FileVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
+++ b/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <AssemblyVersion>1.3.2.0</AssemblyVersion>
-    <FileVersion>1.3.2.0</FileVersion>
-    <Version>1.3.2</Version>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <FileVersion>1.4.0.0</FileVersion>
+    <Version>1.4.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
+++ b/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <AssemblyVersion>1.3.2.0</AssemblyVersion>
-    <FileVersion>1.3.2.0</FileVersion>
-    <Version>1.3.2</Version>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <FileVersion>1.4.0.0</FileVersion>
+    <Version>1.4.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets/Client/Core/RestClient.cs
+++ b/Intuit.TSheets/Client/Core/RestClient.cs
@@ -39,7 +39,7 @@ namespace Intuit.TSheets.Client.Core
     {
         private const string ProductName = "TSheets-V1-DotNET-SDK";
         private const string ProductVersion = "2.0";
-        
+
         private readonly HttpClient httpClient;
         private readonly DataServiceContext context;
         private readonly ILogger logger;
@@ -123,7 +123,7 @@ namespace Intuit.TSheets.Client.Core
 
             LogMethodCall(MethodType.Post, requestUri, logContext, requestData);
 
-            HttpContent content = new StringContent(requestData, Encoding.UTF8);
+            HttpContent content = new StringContent(requestData, Encoding.UTF8, "application/json");
             HttpResponseMessage response = await this.httpClient.PostAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
 
             return ProcessResponse(response, logContext, MethodType.Post);
@@ -170,7 +170,7 @@ namespace Intuit.TSheets.Client.Core
 
             LogMethodCall(MethodType.Put, requestUri, logContext, requestData);
 
-            HttpContent content = new StringContent(requestData, Encoding.UTF8);
+            HttpContent content = new StringContent(requestData, Encoding.UTF8, "application/json");
             HttpResponseMessage response = await this.httpClient.PutAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
 
             return ProcessResponse(response, logContext, MethodType.Put);

--- a/Intuit.TSheets/Intuit.TSheets.csproj
+++ b/Intuit.TSheets/Intuit.TSheets.csproj
@@ -9,14 +9,14 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Intuit</Authors>
     <PackageProjectUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</PackageProjectUrl>
-    <AssemblyVersion>1.3.2.0</AssemblyVersion>
-    <FileVersion>1.3.2.0</FileVersion>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <FileVersion>1.4.0.0</FileVersion>
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <PackageIcon>Circle_T_web128px.png</PackageIcon>
     <RepositoryType>Git</RepositoryType>
-    <PackageReleaseNotes>Bugfix: Adding missing GeofenceConfigType enumeration value for 'locations'</PackageReleaseNotes>
+    <PackageReleaseNotes>Feature: Added 'connectWithQuickBooks' property to 'Jobcode' to support the two-way sync feature.</PackageReleaseNotes>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <Version>1.3.2</Version>
+    <Version>1.4.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets/Model/Jobcode.cs
+++ b/Intuit.TSheets/Model/Jobcode.cs
@@ -196,6 +196,9 @@ namespace Intuit.TSheets.Model
 
 
         /// <summary>
+        /// <remarks>
+        /// This is a beta feature. Please leave this value null until it is generally available.
+        /// </remarks>
         /// Gets or sets the value indicating whether or not this jobcode should be shared with QuickBooks.
         /// </summary>
         [JsonProperty("connect_with_quickbooks")]

--- a/Intuit.TSheets/Model/Jobcode.cs
+++ b/Intuit.TSheets/Model/Jobcode.cs
@@ -193,5 +193,12 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [JsonProperty("project_id")]
         public int? ProjectId { get; internal set; }
+
+
+        /// <summary>
+        /// Gets or sets the value indicating whether or not this jobcode should be shared with QuickBooks.
+        /// </summary>
+        [JsonProperty("connect_with_quickbooks")]
+        public bool? ConnectWithQuickBooks { get; set; }
     }
 }

--- a/Intuit.TSheets/Model/Schemas/Jobcode.xsd
+++ b/Intuit.TSheets/Model/Schemas/Jobcode.xsd
@@ -19,7 +19,8 @@
     "last_modified",
     "created",
     "locations",
-    "project_id"
+    "project_id",
+    "connect_with_quickbooks"
   ],
   "properties": {
     "id": {
@@ -90,6 +91,9 @@
     "project_id": {
       "type": "integer",
       "format": "int32"
+    },
+    "connect_with_quickbooks": {
+      "type": "boolean"
     }
   },
   "definitions": {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TSheets-V1-DotNET-SDK
 **Support:** [![Help](https://img.shields.io/badge/Support-TSheets%20Developer-blue.svg)](https://www.tsheets.com/contact-tsheets)<br/>
 **Documentation:** [![User Guide](https://img.shields.io/badge/User%20Guide-SDK%20Docs-blue.svg)](./Documentation/tsheets-sdk.md)<br/>
 **Continuous Integration:** [![Build Status](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)<br/>
-**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.3.2-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
+**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.4.0-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
 
 The TSheets .NET SDK provides class libraries for accessing the TSheets API quickly, easily, and with confidence.
 It supports .Net Standard 2.0, and .Net Framework 4.7.2.


### PR DESCRIPTION
### What Changed?
Added support for the new connect_with_quickbooks jobcode API property. This new property is part of the two-way sync beta. it is only available when the two-way sync feature is enabled.

### Why?
The Karbon third-party app needs to be able to pass this property to the jobcode API.

### What else might be impacted?
Nothing

## Checklist

- [x] Documentation
- [x] Unit Tests
- [x] Added self to contributors
- [x] Added SemVer label
- [x] Ready to be merged