### PR TITLE
v1.4.1 BREAKING CHANGE - Fixing issue #22 (Geolocation.Id is more tha…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.4.1 (Wed. Jul 14th, 2021)
+
+#### THIS IS A BREAKING CHANGE RELEASE
+ - Addressing issue #22: All entity and entity reference ID's are now data type _long_.
+
 # v1.4.0 (Wed. Jan 13, 2021)
 
 #### Feature

--- a/Intuit.TSheets.Examples/ExampleAppService.cs
+++ b/Intuit.TSheets.Examples/ExampleAppService.cs
@@ -318,7 +318,7 @@ namespace Intuit.TSheets.Examples
                 Zip = "83616",
                 LinkedObjects = new LocationLinkedObjectIds
                 {
-                    Jobcodes = new List<int> { jobcode.Id }
+                    Jobcodes = new List<long> { jobcode.Id }
                 }
             };
 

--- a/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
+++ b/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
@@ -13,8 +13,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
     <PackageReleaseNotes />
-    <AssemblyVersion>1.4.0.0</AssemblyVersion>
-    <Version>1.4.0</Version>
+    <AssemblyVersion>1.4.1.0</AssemblyVersion>
+    <Version>1.4.1</Version>
     <FileVersion>1.4.0.0</FileVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
+++ b/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <AssemblyVersion>1.4.0.0</AssemblyVersion>
-    <FileVersion>1.4.0.0</FileVersion>
-    <Version>1.4.0</Version>
+    <AssemblyVersion>1.4.1.0</AssemblyVersion>
+    <FileVersion>1.4.1.0</FileVersion>
+    <Version>1.4.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
+++ b/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <AssemblyVersion>1.4.0.0</AssemblyVersion>
-    <FileVersion>1.4.0.0</FileVersion>
-    <Version>1.4.0</Version>
+    <AssemblyVersion>1.4.1.0</AssemblyVersion>
+    <FileVersion>1.4.1.0</FileVersion>
+    <Version>1.4.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets.Tests/Unit/Api/DataService_FilesTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataService_FilesTests.cs
@@ -328,7 +328,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
         {
             ExpectDelete<File>(EndpointName.Files);
 
-            ApiService.DeleteFiles(new[]{ 1, 2 });
+            ApiService.DeleteFiles(new long[]{ 1, 2 });
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -360,7 +360,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
         {
             ExpectDelete<File>(EndpointName.Files);
 
-            await ApiService.DeleteFilesAsync(new[] { 1, 2 }).ConfigureAwait(false);
+            await ApiService.DeleteFilesAsync(new long[] { 1, 2 }).ConfigureAwait(false);
         }
 
         #endregion

--- a/Intuit.TSheets.Tests/Unit/Api/DataService_GeolocationsTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataService_GeolocationsTests.cs
@@ -31,7 +31,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
     {
         private static readonly GeolocationFilter DummyFilter = new GeolocationFilter
         {
-            Ids = new[] { 1, 2 }
+            Ids = new long[] { 1, 2 }
         };
 
         private static readonly Geolocation DummyEntity = new Geolocation();

--- a/Intuit.TSheets.Tests/Unit/Api/DataService_JobcodeAssignmentsTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataService_JobcodeAssignmentsTests.cs
@@ -222,7 +222,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
         {
             ExpectDelete<JobcodeAssignment>(EndpointName.JobcodeAssignments);
 
-            ApiService.DeleteJobcodeAssignments(new[] { 1, 2 });
+            ApiService.DeleteJobcodeAssignments(new long[] { 1, 2 });
         }
 
 
@@ -255,7 +255,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
         {
             ExpectDelete<JobcodeAssignment>(EndpointName.JobcodeAssignments);
 
-            await ApiService.DeleteJobcodeAssignmentsAsync(new[] { 1, 2 }).ConfigureAwait(false);
+            await ApiService.DeleteJobcodeAssignmentsAsync(new long[] { 1, 2 }).ConfigureAwait(false);
         }
 
         #endregion

--- a/Intuit.TSheets.Tests/Unit/Api/DataService_NotificationsTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataService_NotificationsTests.cs
@@ -31,7 +31,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
     {
         private static readonly NotificationFilter DummyFilter = new NotificationFilter
         {
-            Ids = new[] { 1, 2}
+            Ids = new long[] { 1, 2}
         };
 
         private static readonly Notification DummyEntity = new Notification();
@@ -222,7 +222,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
         {
             ExpectDelete<Notification>(EndpointName.Notifications);
 
-            ApiService.DeleteNotifications(new[] { 1, 2 });
+            ApiService.DeleteNotifications(new long[] { 1, 2 });
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -254,7 +254,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
         {
             ExpectDelete<Notification>(EndpointName.Notifications);
 
-            await ApiService.DeleteNotificationsAsync(new[] { 1, 2 }).ConfigureAwait(false);
+            await ApiService.DeleteNotificationsAsync(new long[] { 1, 2 }).ConfigureAwait(false);
         }
 
         #endregion

--- a/Intuit.TSheets.Tests/Unit/Api/DataService_RemindersTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataService_RemindersTests.cs
@@ -31,7 +31,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
     {
         private static readonly ReminderFilter DummyFilter = new ReminderFilter
         {
-            UserIds = new[] { 1, 2 }
+            UserIds = new long[] { 1, 2 }
         };
 
         private static readonly Reminder DummyEntity = new Reminder();

--- a/Intuit.TSheets.Tests/Unit/Api/DataService_ReportsTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataService_ReportsTests.cs
@@ -31,7 +31,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
     {
         private static readonly CurrentTotalsReportFilter DummyCurrentTotalsReportFilter = new CurrentTotalsReportFilter
         {
-            UserIds = new[]{ 1, 2 }
+            UserIds = new long[]{ 1, 2 }
         };
 
         private static readonly PayrollReportFilter DummyPayrollReportFilter = new PayrollReportFilter(

--- a/Intuit.TSheets.Tests/Unit/Api/DataService_ScheduleCalendarsTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataService_ScheduleCalendarsTests.cs
@@ -30,7 +30,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
     {
         private static readonly ScheduleCalendarFilter DummyFilter = new ScheduleCalendarFilter
         {
-            Ids = new[]{ 1, 2 }
+            Ids = new long[]{ 1, 2 }
         };
 
         #region Get Method Tests

--- a/Intuit.TSheets.Tests/Unit/Api/DataService_ScheduleEventsTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataService_ScheduleEventsTests.cs
@@ -31,7 +31,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
     {
         private static readonly ScheduleEventFilter DummyFilter = new ScheduleEventFilter
         {
-            Ids = new[] { 1, 2 }
+            Ids = new long[] { 1, 2 }
         };
 
         private static readonly ScheduleEvent DummyEntity = new ScheduleEvent();

--- a/Intuit.TSheets.Tests/Unit/Api/DataService_TimesheetsDeletedTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataService_TimesheetsDeletedTests.cs
@@ -30,7 +30,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
     {
         private static readonly TimesheetsDeletedFilter DummyFilter = new TimesheetsDeletedFilter
         {
-            Ids = new[] { 1, 2 }
+            Ids = new long[] { 1, 2 }
         };
 
         #region Get Method Tests

--- a/Intuit.TSheets.Tests/Unit/Api/DataService_TimesheetsTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Api/DataService_TimesheetsTests.cs
@@ -31,7 +31,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
     {
         private static readonly TimesheetFilter DummyFilter = new TimesheetFilter
         {
-            Ids = new[] { 1, 2 }
+            Ids = new long[] { 1, 2 }
         };
 
         private static readonly Timesheet DummyEntity = new Timesheet();
@@ -260,7 +260,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
         {
             ExpectDelete<Timesheet>(EndpointName.Timesheets);
 
-            ApiService.DeleteTimesheets(new[] { 1, 2 });
+            ApiService.DeleteTimesheets(new long[] { 1, 2 });
         }
 
         [TestMethod, TestCategory("Unit")]
@@ -292,7 +292,7 @@ namespace Intuit.TSheets.Tests.Unit.Api
         {
             ExpectDelete<Timesheet>(EndpointName.Timesheets);
 
-            await ApiService.DeleteTimesheetsAsync(new[] { 1, 2 }).ConfigureAwait(false);
+            await ApiService.DeleteTimesheetsAsync(new long[] { 1, 2 }).ConfigureAwait(false);
         }
 
         #endregion

--- a/Intuit.TSheets.Tests/Unit/BasicTestEntity.cs
+++ b/Intuit.TSheets.Tests/Unit/BasicTestEntity.cs
@@ -41,7 +41,7 @@ namespace Intuit.TSheets.Tests.Unit
         }
 
         [JsonProperty("id")]
-        public int Id { get; private set; }
+        public long Id { get; private set; }
 
         [JsonProperty("name")]
         public string Name { get; private set; }

--- a/Intuit.TSheets.Tests/Unit/Client/Core/ResilientRestClientTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/Core/ResilientRestClientTests.cs
@@ -44,7 +44,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
         private EndpointName endpointName;
         private string inputData;
         private Dictionary<string, string> inputFilter;
-        private List<int> deleteIds;
+        private List<long> deleteIds;
         private LogContext logContext;
         private Mock<IRestClient> mockRestClient;
 
@@ -56,7 +56,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             this.endpointName = EndpointName.Tests;
             this.inputData = "{ \"input\": \"data\" }";
             this.inputFilter = new Dictionary<string, string> { { "ids", "1,2,3"} };
-            this.deleteIds = new List<int>{1, 2, 3};
+            this.deleteIds = new List<long>{1, 2, 3};
             this.logContext = new LogContext();
             this.mockRestClient = new Mock<IRestClient>();
         }
@@ -399,10 +399,10 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             this.mockRestClient
                 .Setup(c => c.DeleteAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
-                    It.Is<IEnumerable<int>>(j => j.Equals(this.deleteIds)),
+                    It.Is<IEnumerable<long>>(j => j.Equals(this.deleteIds)),
                     It.Is<LogContext>(l => l.Equals(this.logContext)),
                     It.IsAny<CancellationToken>()))
-                .Callback((EndpointName en, IEnumerable<int> di, LogContext lc, CancellationToken ct)
+                .Callback((EndpointName en, IEnumerable<long> di, LogContext lc, CancellationToken ct)
                     => throw new ServiceUnavailableException("Something went wrong."));
 
             try
@@ -428,7 +428,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             this.mockRestClient
                 .Setup(c => c.DeleteAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
-                    It.Is<IEnumerable<int>>(j => j.Equals(this.deleteIds)),
+                    It.Is<IEnumerable<long>>(j => j.Equals(this.deleteIds)),
                     It.Is<LogContext>(l => l.Equals(this.logContext)),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult("Done."));
@@ -452,10 +452,10 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
             this.mockRestClient
                 .Setup(c => c.DeleteAsync(
                     It.Is<EndpointName>(e => e.Equals(this.endpointName)),
-                    It.Is<IEnumerable<int>>(j => j.Equals(this.deleteIds)),
+                    It.Is<IEnumerable<long>>(j => j.Equals(this.deleteIds)),
                     It.Is<LogContext>(l => l.Equals(this.logContext)),
                     It.IsAny<CancellationToken>()))
-                .Callback((EndpointName en, IEnumerable<int> di, LogContext lc, CancellationToken ct)
+                .Callback((EndpointName en, IEnumerable<long> di, LogContext lc, CancellationToken ct)
                     => throw new BadRequestException("Bad request."));
 
             try

--- a/Intuit.TSheets.Tests/Unit/Client/Core/RestClientTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/Core/RestClientTests.cs
@@ -416,7 +416,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
         [TestMethod, TestCategory("Unit")]
         public async Task DeleteAsync_ReturnsExpectedResponse()
         {
-            var expectedRequest = new int[] { 1, 2, 3 };
+            var expectedRequest = new long[] { 1, 2, 3 };
             string expectedResponse = "success";
 
             var mockHttpClient = GetMockHttpClient(
@@ -440,7 +440,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
         public async Task DeleteAsync_IsCalledWithExpectedInputs()
         {
             Uri expectedUri = new Uri("https://rest.tsheets.com/api/v1/tests?ids=1%2C2%2C3");
-            var expectedRequest = new int[] { 1, 2, 3 };
+            var expectedRequest = new long[] { 1, 2, 3 };
 
             var mockHttpClient = GetMockHttpClient(
                 (HttpRequestMessage request, CancellationToken token) =>
@@ -466,7 +466,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.Core
         [ExpectedException(typeof(ExpectationFailedException))]
         public async Task DeleteAsync_ThrowsOnError()
         {
-            var expectedRequest = new int[] { 1, 2, 3 };
+            var expectedRequest = new long[] { 1, 2, 3 };
 
             var mockHttpClient = GetMockHttpClient(
                 new HttpResponseMessage()

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/DeleteContextValidatorTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/DeleteContextValidatorTests.cs
@@ -53,7 +53,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         [ExpectedException(typeof(BadRequestException))]
         public async Task DeleteContextValidator_ThrowsWhenInputIdsIsEmpty()
         {
-            var context = new DeleteContext<TestEntity>(EndpointName.Tests, new List<int>());
+            var context = new DeleteContext<TestEntity>(EndpointName.Tests, new List<long>());
 
             await this.pipelineElement.ProcessAsync(context, MockLogger.Object, default)
                 .ConfigureAwait(false);

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/DeleteResultsDeserializerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/DeleteResultsDeserializerTests.cs
@@ -78,7 +78,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
               }
             }";
 
-            return new DeleteContext<T>(EndpointName.Tests, new[]{ 135694294, 135694494 })
+            return new DeleteContext<T>(EndpointName.Tests, new long[]{ 135694294, 135694494 })
             {
                 ResponseContent = responseContent
             };
@@ -109,7 +109,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
               }
             }";
 
-            return new DeleteContext<T>(EndpointName.Tests, new[]{ 135694294, 135694494, 135694495 })
+            return new DeleteContext<T>(EndpointName.Tests, new long[]{ 135694294, 135694494, 135694495 })
             {
                 ResponseContent = responseContent
             };

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/RestClientDeleteHandlerTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/PipelineElements/RestClientDeleteHandlerTests.cs
@@ -47,14 +47,14 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
         [TestMethod, TestCategory("Unit")]
         public async Task RestClientDeleteHandler_RestClientIsInvokedWithExpectedInputsAsync()
         {
-            var idsToDelete = new List<int> { 1, 2, 3 };
+            var idsToDelete = new List<long> { 1, 2, 3 };
 
             // rest client Delete() method is called with 3 parameters: 
             // the request id, the endpoint, and the list of id's to delete
             this.mockRestClient
                 .Setup(p => p.DeleteAsync(
                     It.Is<EndpointName>(t => t.Equals(EndpointName.Tests)),
-                    It.Is<IEnumerable<int>>(s => s.IsEqualTo(idsToDelete)),
+                    It.Is<IEnumerable<long>>(s => s.IsEqualTo(idsToDelete)),
                     It.IsAny<LogContext>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response));
@@ -75,12 +75,12 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.PipelineElements
             this.mockRestClient
                 .Setup(p => p.DeleteAsync(
                     It.IsAny<EndpointName>(),
-                    It.IsAny<IEnumerable<int>>(),
+                    It.IsAny<IEnumerable<long>>(),
                     It.IsAny<LogContext>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response));
 
-            var context = new DeleteContext<BasicTestEntity>(EndpointName.Tests, new[] {1})
+            var context = new DeleteContext<BasicTestEntity>(EndpointName.Tests, new long[] {1})
             {
                 RestClient = this.mockRestClient.Object
             };

--- a/Intuit.TSheets.Tests/Unit/Client/RequestFlow/Pipelines/PipelineFactoryTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/RequestFlow/Pipelines/PipelineFactoryTests.cs
@@ -258,7 +258,7 @@ namespace Intuit.TSheets.Tests.Unit.Client.RequestFlow.Pipelines
         {
             var context = new DeleteContext<TestEntity>(
                 EndpointName.Tests,
-                new[]{ 1, 2, 3 });
+                new long[]{ 1, 2, 3 });
 
             var pipeline = (RequestPipeline)this.pipelineFactory.GetPipeline(context);
 

--- a/Intuit.TSheets.Tests/Unit/TestEntity.cs
+++ b/Intuit.TSheets.Tests/Unit/TestEntity.cs
@@ -41,7 +41,7 @@ namespace Intuit.TSheets.Tests.Unit
 
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/Intuit.TSheets/Api/DataService_Files.cs
+++ b/Intuit.TSheets/Api/DataService_Files.cs
@@ -580,7 +580,7 @@ namespace Intuit.TSheets.Api
         /// </summary>
         /// <param name="id">The id the of the image file to download.</param>
         /// <returns>An array of bytes, representing the image content.</returns>
-        public byte[] DownloadFile(int id)
+        public byte[] DownloadFile(long id)
         {
             return AsyncUtil.RunSync(() => DownloadFileAsync(id));
         }
@@ -591,7 +591,7 @@ namespace Intuit.TSheets.Api
         /// <param name="id">The id the of the image file to download.</param>
         /// <returns>An array of bytes, representing the image content.</returns>
         public async Task<byte[]> DownloadFileAsync(
-            int id)
+            long id)
         {
             return await DownloadFileAsync(id, default).ConfigureAwait(false);
         }
@@ -605,7 +605,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>An array of bytes, representing the image content.</returns>
         public async Task<byte[]> DownloadFileAsync(
-            int id,
+            long id,
             CancellationToken cancellationToken)
         {
             var context = new DownloadContext<File>(EndpointName.FilesRaw, new FileDownloadFilter(id));
@@ -642,7 +642,7 @@ namespace Intuit.TSheets.Api
         /// <param name="id">
         /// The id of the <see cref="File"/> object to be deleted.
         /// </param>
-        public void DeleteFile(int id)
+        public void DeleteFile(long id)
         {
             AsyncUtil.RunSync(() => DeleteFileAsync(id));
         }
@@ -670,7 +670,7 @@ namespace Intuit.TSheets.Api
         /// <param name="ids">
         /// The set of ids for the <see cref="File"/> objects to be deleted.
         /// </param>
-        public void DeleteFiles(IEnumerable<int> ids)
+        public void DeleteFiles(IEnumerable<long> ids)
         {
             AsyncUtil.RunSync(() => DeleteFilesAsync(ids));
         }
@@ -722,7 +722,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteFileAsync(
-            int id)
+            long id)
         {
             await DeleteFilesAsync(new[] { id }, default).ConfigureAwait(false);
         }
@@ -741,7 +741,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteFileAsync(
-            int id,
+            long id,
             CancellationToken cancellationToken)
         {
             await DeleteFilesAsync(new[] { id }, cancellationToken).ConfigureAwait(false);
@@ -760,7 +760,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteFilesAsync(
             IEnumerable<File> files)
         {
-            IEnumerable<int> ids = files?.Select(t => t.Id);
+            IEnumerable<long> ids = files?.Select(t => t.Id);
 
             await DeleteFilesAsync(ids, default).ConfigureAwait(false);
         }
@@ -782,7 +782,7 @@ namespace Intuit.TSheets.Api
             IEnumerable<File> files,
             CancellationToken cancellationToken)
         {
-            IEnumerable<int> ids = files?.Select(t => t.Id);
+            IEnumerable<long> ids = files?.Select(t => t.Id);
 
             await DeleteFilesAsync(ids, cancellationToken).ConfigureAwait(false);
         }
@@ -798,7 +798,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteFilesAsync(
-            IEnumerable<int> ids)
+            IEnumerable<long> ids)
         {
             await DeleteFilesAsync(ids, default).ConfigureAwait(false);
         }
@@ -817,7 +817,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteFilesAsync(
-            IEnumerable<int> ids,
+            IEnumerable<long> ids,
             CancellationToken cancellationToken)
         {
             var context = new DeleteContext<File>(EndpointName.Files, ids);

--- a/Intuit.TSheets/Api/DataService_JobcodeAssignments.cs
+++ b/Intuit.TSheets/Api/DataService_JobcodeAssignments.cs
@@ -460,7 +460,7 @@ namespace Intuit.TSheets.Api
         /// <param name="id">
         /// The id of the <see cref="JobcodeAssignment"/> assignment object to be deleted.
         /// </param>
-        public void DeleteJobcodeAssignment(int id)
+        public void DeleteJobcodeAssignment(long id)
         {
             AsyncUtil.RunSync(() => DeleteJobcodeAssignmentAsync(id));
         }
@@ -489,7 +489,7 @@ namespace Intuit.TSheets.Api
         /// <param name="ids">
         /// The set of ids for the <see cref="JobcodeAssignment"/> assignment objects to be deleted.
         /// </param>
-        public void DeleteJobcodeAssignments(IEnumerable<int> ids)
+        public void DeleteJobcodeAssignments(IEnumerable<long> ids)
         {
             AsyncUtil.RunSync(() => DeleteJobcodeAssignmentsAsync(ids));
         }
@@ -541,7 +541,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteJobcodeAssignmentAsync(
-            int id)
+            long id)
         {
             await DeleteJobcodeAssignmentsAsync(new[] { id }, default).ConfigureAwait(false);
         }
@@ -560,7 +560,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteJobcodeAssignmentAsync(
-            int id,
+            long id,
             CancellationToken cancellationToken)
         {
             await DeleteJobcodeAssignmentsAsync(new[] { id }, cancellationToken).ConfigureAwait(false);
@@ -579,7 +579,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteJobcodeAssignmentsAsync(
             IEnumerable<JobcodeAssignment> jobcodeAssignments)
         {
-            IEnumerable<int> ids = jobcodeAssignments.Select(t => t.Id);
+            IEnumerable<long> ids = jobcodeAssignments.Select(t => t.Id);
 
             await DeleteJobcodeAssignmentsAsync(ids, default).ConfigureAwait(false);
         }
@@ -601,7 +601,7 @@ namespace Intuit.TSheets.Api
             IEnumerable<JobcodeAssignment> jobcodeAssignments,
             CancellationToken cancellationToken)
         {
-            IEnumerable<int> ids = jobcodeAssignments.Select(t => t.Id);
+            IEnumerable<long> ids = jobcodeAssignments.Select(t => t.Id);
 
             await DeleteJobcodeAssignmentsAsync(ids, cancellationToken).ConfigureAwait(false);
         }
@@ -617,7 +617,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteJobcodeAssignmentsAsync(
-            IEnumerable<int> ids)
+            IEnumerable<long> ids)
         {
             await DeleteJobcodeAssignmentsAsync(ids, default).ConfigureAwait(false);
         }
@@ -636,7 +636,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteJobcodeAssignmentsAsync(
-            IEnumerable<int> ids,
+            IEnumerable<long> ids,
             CancellationToken cancellationToken)
         {
             var context = new DeleteContext<JobcodeAssignment>(EndpointName.JobcodeAssignments, ids);

--- a/Intuit.TSheets/Api/DataService_Notifications.cs
+++ b/Intuit.TSheets/Api/DataService_Notifications.cs
@@ -460,7 +460,7 @@ namespace Intuit.TSheets.Api
         /// <param name="id">
         /// The id of the <see cref="Notification"/> object to be deleted.
         /// </param>
-        public void DeleteNotification(int id)
+        public void DeleteNotification(long id)
         {
             AsyncUtil.RunSync(() => DeleteNotificationAsync(id));
         }
@@ -488,7 +488,7 @@ namespace Intuit.TSheets.Api
         /// <param name="ids">
         /// The set of ids for the <see cref="Notification"/> objects to be deleted.
         /// </param>
-        public void DeleteNotifications(IEnumerable<int> ids)
+        public void DeleteNotifications(IEnumerable<long> ids)
         {
             AsyncUtil.RunSync(() => DeleteNotificationsAsync(ids));
         }
@@ -540,7 +540,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteNotificationAsync(
-            int id)
+            long id)
         {
             await DeleteNotificationsAsync(new[] { id }, default).ConfigureAwait(false);
         }
@@ -559,7 +559,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteNotificationAsync(
-            int id,
+            long id,
             CancellationToken cancellationToken)
         {
             await DeleteNotificationsAsync(new[] { id }, cancellationToken).ConfigureAwait(false);
@@ -578,7 +578,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteNotificationsAsync(
             IEnumerable<Notification> notifications)
         {
-            IEnumerable<int> ids = notifications.Select(t => t.Id);
+            IEnumerable<long> ids = notifications.Select(t => t.Id);
 
             await DeleteNotificationsAsync(ids, default).ConfigureAwait(false);
         }
@@ -600,7 +600,7 @@ namespace Intuit.TSheets.Api
             IEnumerable<Notification> notifications,
             CancellationToken cancellationToken)
         {
-            IEnumerable<int> ids = notifications.Select(t => t.Id);
+            IEnumerable<long> ids = notifications.Select(t => t.Id);
 
             await DeleteNotificationsAsync(ids, cancellationToken).ConfigureAwait(false);
         }
@@ -616,7 +616,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteNotificationsAsync(
-            IEnumerable<int> ids)
+            IEnumerable<long> ids)
         {
             await DeleteNotificationsAsync(ids, default).ConfigureAwait(false);
         }
@@ -635,7 +635,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteNotificationsAsync(
-            IEnumerable<int> ids,
+            IEnumerable<long> ids,
             CancellationToken cancellationToken)
         {
             var context = new DeleteContext<Notification>(EndpointName.Notifications, ids);

--- a/Intuit.TSheets/Api/DataService_Timesheet.cs
+++ b/Intuit.TSheets/Api/DataService_Timesheet.cs
@@ -482,7 +482,7 @@ namespace Intuit.TSheets.Api
         /// <param name="id">
         /// The id of the <see cref="Timesheet"/> object to be deleted.
         /// </param>
-        public void DeleteTimesheet(int id)
+        public void DeleteTimesheet(long id)
         {
             AsyncUtil.RunSync(() => DeleteTimesheetAsync(id));
         }
@@ -510,7 +510,7 @@ namespace Intuit.TSheets.Api
         /// <param name="ids">
         /// The set of ids for the <see cref="Timesheet"/> objects to be deleted.
         /// </param>
-        public void DeleteTimesheets(IEnumerable<int> ids)
+        public void DeleteTimesheets(IEnumerable<long> ids)
         {
             AsyncUtil.RunSync(() => DeleteTimesheetsAsync(ids));
         }
@@ -562,7 +562,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteTimesheetAsync(
-            int id)
+            long id)
         {
             await DeleteTimesheetsAsync(new[] { id }, default).ConfigureAwait(false);
         }
@@ -581,7 +581,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteTimesheetAsync(
-            int id,
+            long id,
             CancellationToken cancellationToken)
         {
             await DeleteTimesheetsAsync(new[] { id }, cancellationToken).ConfigureAwait(false);
@@ -600,7 +600,7 @@ namespace Intuit.TSheets.Api
         public async Task DeleteTimesheetsAsync(
             IEnumerable<Timesheet> timesheets)
         {
-            IEnumerable<int> ids = timesheets.Select(t => t.Id);
+            IEnumerable<long> ids = timesheets.Select(t => t.Id);
 
             await DeleteTimesheetsAsync(ids, default).ConfigureAwait(false);
         }
@@ -622,7 +622,7 @@ namespace Intuit.TSheets.Api
             IEnumerable<Timesheet> timesheets,
             CancellationToken cancellationToken)
         {
-            IEnumerable<int> ids = timesheets.Select(t => t.Id);
+            IEnumerable<long> ids = timesheets.Select(t => t.Id);
 
             await DeleteTimesheetsAsync(ids, cancellationToken).ConfigureAwait(false);
         }
@@ -638,7 +638,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteTimesheetsAsync(
-            IEnumerable<int> ids)
+            IEnumerable<long> ids)
         {
             await DeleteTimesheetsAsync(ids, default).ConfigureAwait(false);
         }
@@ -657,7 +657,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         public async Task DeleteTimesheetsAsync(
-            IEnumerable<int> ids,
+            IEnumerable<long> ids,
             CancellationToken cancellationToken)
         {
             var context = new DeleteContext<Timesheet>(EndpointName.Timesheets, ids);

--- a/Intuit.TSheets/Api/IDataService.cs
+++ b/Intuit.TSheets/Api/IDataService.cs
@@ -2108,7 +2108,7 @@ namespace Intuit.TSheets.Api
         /// <param name="id">The id the of the image file to download.</param>
         /// <returns>An array of bytes, representing the image content.</returns>
         byte[] DownloadFile(
-            int id);
+            long id);
 
         /// <summary>
         /// Asynchronously download the raw bytes of an image file.
@@ -2116,7 +2116,7 @@ namespace Intuit.TSheets.Api
         /// <param name="id">The id the of the image file to download.</param>
         /// <returns>An array of bytes, representing the image content.</returns>
         Task<byte[]> DownloadFileAsync(
-            int id);
+            long id);
 
         /// <summary>
         /// Asynchronously download the raw bytes of an image file, with support for cancellation.
@@ -2127,7 +2127,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>An array of bytes, representing the image content.</returns>
         Task<byte[]> DownloadFileAsync(
-            int id,
+            long id,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -2152,7 +2152,7 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="File"/> object to be deleted.
         /// </param>
         void DeleteFile(
-            int id);
+            long id);
 
         /// <summary>
         /// Delete Files.
@@ -2176,7 +2176,7 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="File"/> objects to be deleted.
         /// </param>
         void DeleteFiles(
-            IEnumerable<int> ids);
+            IEnumerable<long> ids);
 
         /// <summary>
         /// Asynchronously Delete Files.
@@ -2219,7 +2219,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteFileAsync(
-            int id);
+            long id);
 
         /// <summary>
         /// Asynchronously Delete Files, with support for cancellation.
@@ -2235,7 +2235,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteFileAsync(
-            int id,
+            long id,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -2279,7 +2279,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteFilesAsync(
-            IEnumerable<int> ids);
+            IEnumerable<long> ids);
 
         /// <summary>
         /// Asynchronously Delete Files, with support for cancellation.
@@ -2295,7 +2295,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteFilesAsync(
-            IEnumerable<int> ids,
+            IEnumerable<long> ids,
             CancellationToken cancellationToken);
 
         #endregion
@@ -4056,7 +4056,7 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="JobcodeAssignment"/> assignment object to be deleted.
         /// </param>
         void DeleteJobcodeAssignment(
-            int id);
+            long id);
 
         /// <summary>
         /// Delete Jobcode Assignments.
@@ -4080,7 +4080,7 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="JobcodeAssignment"/> assignment objects to be deleted.
         /// </param>
         void DeleteJobcodeAssignments(
-            IEnumerable<int> ids);
+            IEnumerable<long> ids);
 
         /// <summary>
         /// Asynchronously Delete Jobcode Assignments.
@@ -4123,7 +4123,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteJobcodeAssignmentAsync(
-            int id);
+            long id);
 
         /// <summary>
         /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
@@ -4139,7 +4139,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteJobcodeAssignmentAsync(
-            int id,
+            long id,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -4183,7 +4183,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteJobcodeAssignmentsAsync(
-            IEnumerable<int> ids);
+            IEnumerable<long> ids);
 
         /// <summary>
         /// Asynchronously Delete Jobcode Assignments, with support for cancellation.
@@ -4199,7 +4199,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteJobcodeAssignmentsAsync(
-            IEnumerable<int> ids,
+            IEnumerable<long> ids,
             CancellationToken cancellationToken);
 
         #endregion
@@ -5523,7 +5523,7 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="Notification"/> object to be deleted.
         /// </param>
         void DeleteNotification(
-            int id);
+            long id);
 
         /// <summary>
         /// Delete Notifications.
@@ -5547,7 +5547,7 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="Notification"/> objects to be deleted.
         /// </param>
         void DeleteNotifications(
-            IEnumerable<int> ids);
+            IEnumerable<long> ids);
 
         /// <summary>
         /// Asynchronously Delete Notifications.
@@ -5590,7 +5590,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteNotificationAsync(
-            int id);
+            long id);
 
         /// <summary>
         /// Asynchronously Delete Notifications, with support for cancellation.
@@ -5606,7 +5606,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteNotificationAsync(
-            int id,
+            long id,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -5650,7 +5650,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteNotificationsAsync(
-            IEnumerable<int> ids);
+            IEnumerable<long> ids);
 
         /// <summary>
         /// Asynchronously Delete Notifications, with support for cancellation.
@@ -5666,7 +5666,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteNotificationsAsync(
-            IEnumerable<int> ids,
+            IEnumerable<long> ids,
             CancellationToken cancellationToken);
 
         #endregion
@@ -7192,7 +7192,7 @@ namespace Intuit.TSheets.Api
         /// The id of the <see cref="Timesheet"/> object to be deleted.
         /// </param>
         void DeleteTimesheet(
-            int id);
+            long id);
 
         /// <summary>
         /// Delete Timesheets.
@@ -7216,7 +7216,7 @@ namespace Intuit.TSheets.Api
         /// The set of ids for the <see cref="Timesheet"/> objects to be deleted.
         /// </param>
         void DeleteTimesheets(
-            IEnumerable<int> ids);
+            IEnumerable<long> ids);
 
         /// <summary>
         /// Asynchronously Delete Timesheets.
@@ -7259,7 +7259,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteTimesheetAsync(
-            int id);
+            long id);
 
         /// <summary>
         /// Asynchronously Delete Timesheets, with support for cancellation.
@@ -7275,7 +7275,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteTimesheetAsync(
-            int id,
+            long id,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -7319,7 +7319,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteTimesheetsAsync(
-            IEnumerable<int> ids);
+            IEnumerable<long> ids);
 
         /// <summary>
         /// Asynchronously Delete Timesheets, with support for cancellation.
@@ -7335,7 +7335,7 @@ namespace Intuit.TSheets.Api
         /// </param>
         /// <returns>The asynchronous task.</returns>
         Task DeleteTimesheetsAsync(
-            IEnumerable<int> ids,
+            IEnumerable<long> ids,
             CancellationToken cancellationToken);
 
         #endregion

--- a/Intuit.TSheets/Api/SupplementalData.cs
+++ b/Intuit.TSheets/Api/SupplementalData.cs
@@ -34,8 +34,8 @@ namespace Intuit.TSheets.Api
     /// </remarks>
     public class SupplementalData
     {
-        private readonly Dictionary<Type, Dictionary<int, IIdentifiable>> supplementalData
-            = new Dictionary<Type, Dictionary<int, IIdentifiable>>();
+        private readonly Dictionary<Type, Dictionary<long, IIdentifiable>> supplementalData
+            = new Dictionary<Type, Dictionary<long, IIdentifiable>>();
 
         /// <summary>
         /// Returns a supplemental data entity of given type, having the provided id.
@@ -46,7 +46,7 @@ namespace Intuit.TSheets.Api
         /// <exception cref="NotFoundException">
         /// Not found exception is thrown if no entity with given id exists for the provided type.
         /// </exception>
-        public T GetById<T>(int id)
+        public T GetById<T>(long id)
             where T : IIdentifiable
         {
             Type type = typeof(T);
@@ -95,7 +95,7 @@ namespace Intuit.TSheets.Api
             Type type = entity.GetType();
             if (!this.supplementalData.ContainsKey(type))
             {
-                this.supplementalData.Add(type, new Dictionary<int, IIdentifiable>());
+                this.supplementalData.Add(type, new Dictionary<long, IIdentifiable>());
             }
 
             this.supplementalData[type][entity.Id] = entity;

--- a/Intuit.TSheets/Client/Core/IRestClient.cs
+++ b/Intuit.TSheets/Client/Core/IRestClient.cs
@@ -105,7 +105,7 @@ namespace Intuit.TSheets.Client.Core
         /// <returns>The serialized response of the API method call.</returns>
         Task<string> DeleteAsync(
             EndpointName endpointName,
-            IEnumerable<int> ids,
+            IEnumerable<long> ids,
             LogContext logContext,
             CancellationToken cancellationToken);
     }

--- a/Intuit.TSheets/Client/Core/ResilientRestClient.cs
+++ b/Intuit.TSheets/Client/Core/ResilientRestClient.cs
@@ -186,7 +186,7 @@ namespace Intuit.TSheets.Client.Core
         /// <returns>The serialized response of the API method call.</returns>
         public async Task<string> DeleteAsync(
             EndpointName endpointName,
-            IEnumerable<int> ids,
+            IEnumerable<long> ids,
             LogContext logContext,
             CancellationToken cancellationToken)
         {

--- a/Intuit.TSheets/Client/Core/RestClient.cs
+++ b/Intuit.TSheets/Client/Core/RestClient.cs
@@ -186,7 +186,7 @@ namespace Intuit.TSheets.Client.Core
         /// <returns>The serialized response of the API method call.</returns>
         public async Task<string> DeleteAsync(
             EndpointName endpointName,
-            IEnumerable<int> ids,
+            IEnumerable<long> ids,
             LogContext logContext,
             CancellationToken cancellationToken)
         {

--- a/Intuit.TSheets/Client/RequestFlow/Contexts/DeleteContext.cs
+++ b/Intuit.TSheets/Client/RequestFlow/Contexts/DeleteContext.cs
@@ -37,10 +37,10 @@ namespace Intuit.TSheets.Client.RequestFlow.Contexts
         /// </summary>
         /// <param name="endpoint">The endpoint with which to interact.</param>
         /// <param name="ids">The set of ids corresponding to the data entities to be deleted.</param>
-        internal DeleteContext(EndpointName endpoint, IEnumerable<int> ids)
+        internal DeleteContext(EndpointName endpoint, IEnumerable<long> ids)
             : base(MethodType.Delete, endpoint)
         {
-            List<int> listIds = ids?.ToList();
+            List<long> listIds = ids?.ToList();
             if (listIds == null || !listIds.Any())
             {
                 throw new BadRequestException("Request cannot contain a null or empty set of ids.");
@@ -53,6 +53,6 @@ namespace Intuit.TSheets.Client.RequestFlow.Contexts
         /// Gets the set of ids corresponding to the data entities to be deleted.
         /// </summary>
         [JsonProperty]
-        internal IEnumerable<int> Ids { get; private set; }
+        internal IEnumerable<long> Ids { get; private set; }
     }
 }

--- a/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientDeleteHandler.cs
+++ b/Intuit.TSheets/Client/RequestFlow/PipelineElements/RestClientDeleteHandler.cs
@@ -49,7 +49,7 @@ namespace Intuit.TSheets.Client.RequestFlow.PipelineElements
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            IEnumerable<int> ids = ((DeleteContext<T>)context).Ids;
+            IEnumerable<long> ids = ((DeleteContext<T>)context).Ids;
 
             context.ResponseContent = await context.RestClient.DeleteAsync(
                 context.Endpoint,

--- a/Intuit.TSheets/Client/Serialization/Converters/EnumerableToCsvConverter.cs
+++ b/Intuit.TSheets/Client/Serialization/Converters/EnumerableToCsvConverter.cs
@@ -103,6 +103,10 @@ namespace Intuit.TSheets.Client.Serialization.Converters
                     csv = string.Join(",", intsValue);
                     break;
 
+                case IEnumerable<long> longsValue:
+                    csv = string.Join(",", longsValue);
+                    break;
+
                 default:
                     throw new InvalidOperationException("Unexpected type.");
             }

--- a/Intuit.TSheets/Intuit.TSheets.csproj
+++ b/Intuit.TSheets/Intuit.TSheets.csproj
@@ -9,14 +9,15 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Intuit</Authors>
     <PackageProjectUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</PackageProjectUrl>
-    <AssemblyVersion>1.4.0.0</AssemblyVersion>
-    <FileVersion>1.4.0.0</FileVersion>
+    <AssemblyVersion>1.4.1.0</AssemblyVersion>
+    <FileVersion>1.4.1.0</FileVersion>
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <PackageIcon>Circle_T_web128px.png</PackageIcon>
     <RepositoryType>Git</RepositoryType>
-    <PackageReleaseNotes>Feature: Added 'connectWithQuickBooks' property to 'Jobcode' to support the two-way sync feature.</PackageReleaseNotes>
+    <PackageReleaseNotes>THIS IS A BREAKING CHANGE RELEASE:
+All entity and entity reference ID's are now data type _long_.</PackageReleaseNotes>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets/Model/CurrentTotalsReportItem.cs
+++ b/Intuit.TSheets/Model/CurrentTotalsReportItem.cs
@@ -32,7 +32,7 @@ namespace Intuit.TSheets.Model
         ///  Gets the user id to which these totals pertain.
         /// </summary>
         [JsonProperty("user_id")]
-        public int UserId { get; internal set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// Gets the value indicating whether this user is on or off the clock.
@@ -44,19 +44,19 @@ namespace Intuit.TSheets.Model
         /// Gets the timesheet id for the current timesheet.
         /// </summary>
         [JsonProperty("timesheet_id")]
-        public int? TimesheetId { get; internal set; }
+        public long? TimesheetId { get; internal set; }
 
         /// <summary>
         /// Gets the jobcode id for the current timesheet.
         /// </summary>
         [JsonProperty("jobcode_id")]
-        public int? JobcodeId { get; internal set; }
+        public long? JobcodeId { get; internal set; }
 
         /// <summary>
         /// Gets the unique group id for this user (value of zero represents those without a group).
         /// </summary>
         [JsonProperty("group_id")]
-        public int? GroupId { get; internal set; }
+        public long? GroupId { get; internal set; }
 
         /// <summary>
         /// Gets the value indicating whether geolocations are available for the current timesheet.

--- a/Intuit.TSheets/Model/CustomField.cs
+++ b/Intuit.TSheets/Model/CustomField.cs
@@ -66,7 +66,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the status of the custom field.
@@ -172,6 +172,6 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnWrite]
         [JsonProperty("required_customfields")]
-        public IList<int> RequiredCustomFields { get; internal set; }
+        public IList<long> RequiredCustomFields { get; internal set; }
     }
 }

--- a/Intuit.TSheets/Model/CustomFieldItem.cs
+++ b/Intuit.TSheets/Model/CustomFieldItem.cs
@@ -51,7 +51,7 @@ namespace Intuit.TSheets.Model
         /// <param name="customFieldId">
         /// The id for the custom field that this item belongs to.
         /// </param>
-        public CustomFieldItem(string name, int customFieldId)
+        public CustomFieldItem(string name, long customFieldId)
         {
             Name = name;
             CustomFieldId = customFieldId;
@@ -62,13 +62,13 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate] 
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the id for the custom field that this item belongs to.
         /// </summary>
         [JsonProperty("customfield_id")]
-        public int? CustomFieldId { get; set; }
+        public long? CustomFieldId { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the custom field item.
@@ -107,6 +107,6 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnWrite]
         [JsonProperty("required_customfields")]
-        public IReadOnlyList<int> RequiredCustomFields { get; internal set; }
+        public IReadOnlyList<long> RequiredCustomFields { get; internal set; }
     }
 }

--- a/Intuit.TSheets/Model/CustomFieldItemFilter.cs
+++ b/Intuit.TSheets/Model/CustomFieldItemFilter.cs
@@ -41,19 +41,19 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate] 
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the id for the custom field that this filter belongs to.
         /// </summary>
         [JsonProperty("customfield_id")]
-        public int? CustomFieldId { get; set; }
+        public long? CustomFieldId { get; set; }
 
         /// <summary>
         /// Gets or sets the id for the custom field item that this filter belongs to.
         /// </summary>
         [JsonProperty("customfielditem_id")]
-        public int? CustomFieldItemId { get; set; }
+        public long? CustomFieldItemId { get; set; }
 
         /// <summary>
         /// Gets or sets the entity type this filter relates to.
@@ -76,7 +76,7 @@ namespace Intuit.TSheets.Model
         /// jobcode this filter referred to. If requested, the supplemental data will also contain this jobcode.
         /// </remarks>
         [JsonProperty("applies_to_id")]
-        public int? AppliesToId { get; set; }
+        public long? AppliesToId { get; set; }
 
         /// <summary>
         /// Gets or sets the status of the item filter object.

--- a/Intuit.TSheets/Model/CustomFieldItemJobcodeFilter.cs
+++ b/Intuit.TSheets/Model/CustomFieldItemJobcodeFilter.cs
@@ -37,7 +37,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate] 
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets the date/time when last modified.
@@ -54,6 +54,6 @@ namespace Intuit.TSheets.Model
         /// and the value is an array of item ids to which the jobcode is assigned.
         /// </remarks>
         [JsonProperty("filtered_customfielditems")]
-        public IDictionary<string, IList<int>> FilteredCustomFieldItems { get; internal set; }
+        public IDictionary<string, IList<long>> FilteredCustomFieldItems { get; internal set; }
     }
 }

--- a/Intuit.TSheets/Model/CustomFieldItemUserFilter.cs
+++ b/Intuit.TSheets/Model/CustomFieldItemUserFilter.cs
@@ -39,7 +39,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate] 
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the entities filter type.
@@ -65,6 +65,6 @@ namespace Intuit.TSheets.Model
         /// and the value is an array of item ids to which the jobcode is assigned.
         /// </remarks>
         [JsonProperty("filtered_customfielditems")]
-        public IDictionary<string, IList<int>> FilteredCustomFieldItems { get; internal set; }
+        public IDictionary<string, IList<long>> FilteredCustomFieldItems { get; internal set; }
     }
 }

--- a/Intuit.TSheets/Model/File.cs
+++ b/Intuit.TSheets/Model/File.cs
@@ -61,7 +61,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the name of this file.
@@ -84,7 +84,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnWrite]
         [JsonProperty("uploaded_by_user_id")]
-        public int? UploadedByUserId { get; internal set; }
+        public long? UploadedByUserId { get; internal set; }
 
         /// <summary>
         /// Gets the value indicating whether this file is considered deleted.

--- a/Intuit.TSheets/Model/FileLinkedObjectIds.cs
+++ b/Intuit.TSheets/Model/FileLinkedObjectIds.cs
@@ -34,6 +34,6 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnWrite]
         [JsonProperty("timesheets")]
-        public IReadOnlyList<int> Timesheets { get; set; } = new List<int>();
+        public IReadOnlyList<long> Timesheets { get; set; } = new List<long>();
     }
 }

--- a/Intuit.TSheets/Model/Filters/CurrentTotalsReportFilter.cs
+++ b/Intuit.TSheets/Model/Filters/CurrentTotalsReportFilter.cs
@@ -39,7 +39,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("user_ids")]
-        public IEnumerable<int> UserIds { get; set; }
+        public IEnumerable<long> UserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the group ids for which users belonging Only totals for users from these groups will be included.
@@ -47,7 +47,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("group_ids")]
-        public IEnumerable<int> GroupIds { get; set; }
+        public IEnumerable<long> GroupIds { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating filtering by users who are on or off the clock, or both.

--- a/Intuit.TSheets/Model/Filters/CustomFieldFilter.cs
+++ b/Intuit.TSheets/Model/Filters/CustomFieldFilter.cs
@@ -40,7 +40,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether to filter by active or inactive state, or both.

--- a/Intuit.TSheets/Model/Filters/CustomFieldItemFilter.cs
+++ b/Intuit.TSheets/Model/Filters/CustomFieldItemFilter.cs
@@ -48,7 +48,7 @@ namespace Intuit.TSheets.Model.Filters
         /// <param name="customFieldId">
         /// Id of the custom field whose items you'd like to list.
         /// </param>
-        public CustomFieldItemFilter(int customFieldId)
+        public CustomFieldItemFilter(long customFieldId)
         {
             CustomFieldId = customFieldId;
         }
@@ -57,7 +57,7 @@ namespace Intuit.TSheets.Model.Filters
         /// Gets or sets the id of the custom field whose items you'd like to filter on.
         /// </summary>
         [JsonProperty("customfield_id")]
-        public int? CustomFieldId { get; set; }
+        public long? CustomFieldId { get; set; }
 
         /// <summary>
         /// Gets or sets the ids you'd like to filter on.
@@ -65,7 +65,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether to filter by active or inactive state, or both.

--- a/Intuit.TSheets/Model/Filters/CustomFieldItemFilterFilter.cs
+++ b/Intuit.TSheets/Model/Filters/CustomFieldItemFilterFilter.cs
@@ -38,7 +38,7 @@ namespace Intuit.TSheets.Model.Filters
         /// Gets or sets the value to filter results to only those with given jobcode id.
         /// </summary>
         [JsonProperty("jobcode_id")]
-        public int? JobcodeId { get; set; }
+        public long? JobcodeId { get; set; }
 
         /// <summary>
         /// Gets or sets the value to filter results to only those with given user id.
@@ -48,7 +48,7 @@ namespace Intuit.TSheets.Model.Filters
         /// include the 'IncludeUserGroup' parameter.
         /// </remarks>
         [JsonProperty("user_id")]
-        public int? UserId { get; set; }
+        public long? UserId { get; set; }
 
         /// <summary>
         /// Gets or sets the value to filter results to only those with given group id.
@@ -58,7 +58,7 @@ namespace Intuit.TSheets.Model.Filters
         /// include the <see cref="IncludeUserGroup"/> parameter.
         /// </remarks>
         [JsonProperty("group_id")]
-        public int? GroupId { get; set; }
+        public long? GroupId { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether to filter by the user's group.
@@ -88,7 +88,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the date/time for which only results modified before it will be returned.

--- a/Intuit.TSheets/Model/Filters/CustomFieldItemJobcodeFilterFilter.cs
+++ b/Intuit.TSheets/Model/Filters/CustomFieldItemJobcodeFilterFilter.cs
@@ -33,7 +33,7 @@ namespace Intuit.TSheets.Model.Filters
         /// Gets or sets the value to filter results to only those with given jobcode id.
         /// </summary>
         [JsonProperty("jobcode_id")]
-        public int? JobcodeId { get; set; }
+        public long? JobcodeId { get; set; }
 
         /// <summary>
         /// Gets or sets the date/time for which only results modified before it will be returned.

--- a/Intuit.TSheets/Model/Filters/CustomFieldItemUserFilterFilter.cs
+++ b/Intuit.TSheets/Model/Filters/CustomFieldItemUserFilterFilter.cs
@@ -33,13 +33,13 @@ namespace Intuit.TSheets.Model.Filters
         /// Gets or sets the value to filter results to only those with given user id.
         /// </summary>
         [JsonProperty("user_id")]
-        public int? UserId { get; set; }
+        public long? UserId { get; set; }
 
         /// <summary>
         /// Gets or sets the value to filter results to only those with given group id.
         /// </summary>
         [JsonProperty("group_id")]
-        public int? GroupId { get; set; }
+        public long? GroupId { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether to additionally return filters for the user's group.

--- a/Intuit.TSheets/Model/Filters/EffectiveSettingsFilter.cs
+++ b/Intuit.TSheets/Model/Filters/EffectiveSettingsFilter.cs
@@ -38,7 +38,7 @@ namespace Intuit.TSheets.Model.Filters
         /// An admin will see more settings than a regular user will.
         /// </remarks>
         [JsonProperty("user_id")]
-        public int? UserId { get; set; }
+        public long? UserId { get; set; }
 
         /// <summary>
         /// Gets or sets the filter for returning only those settings modified before this date/time.

--- a/Intuit.TSheets/Model/Filters/FileDownloadFilter.cs
+++ b/Intuit.TSheets/Model/Filters/FileDownloadFilter.cs
@@ -31,7 +31,7 @@ namespace Intuit.TSheets.Model.Filters
         /// Initializes a new instance of the <see cref="FileDownloadFilter"/> class.
         /// </summary>
         /// <param name="id">The id of the file to download.</param>
-        internal FileDownloadFilter(int id)
+        internal FileDownloadFilter(long id)
         {
             Id = id;
         }
@@ -40,6 +40,6 @@ namespace Intuit.TSheets.Model.Filters
         /// Gets or sets the id of the file to download.
         /// </summary>
         [JsonProperty("id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
     }
 }

--- a/Intuit.TSheets/Model/Filters/FileFilter.cs
+++ b/Intuit.TSheets/Model/Filters/FileFilter.cs
@@ -40,7 +40,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the ids you'd like to filter on. Only files uploaded by these users will be returned. 
@@ -51,7 +51,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("uploaded_by_user_ids")]
-        public IEnumerable<int> UploadedByUserIds { get; set; }
+        public IEnumerable<long> UploadedByUserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the filter to return only files linked to the given object type.
@@ -65,7 +65,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("object_ids")]
-        public IEnumerable<int> ObjectIds { get; set; }
+        public IEnumerable<long> ObjectIds { get; set; }
 
         /// <summary>
         /// Gets or sets the value for filtering by active or inactive state, or both.

--- a/Intuit.TSheets/Model/Filters/GeofenceConfigFilter.cs
+++ b/Intuit.TSheets/Model/Filters/GeofenceConfigFilter.cs
@@ -40,7 +40,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the geofence configurations you'd like to filter on.
@@ -55,7 +55,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("type_ids")]
-        public IEnumerable<int> TypeIds { get; set; }
+        public IEnumerable<long> TypeIds { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether to return enabled or disabled geofence configurations.

--- a/Intuit.TSheets/Model/Filters/GeolocationFilter.cs
+++ b/Intuit.TSheets/Model/Filters/GeolocationFilter.cs
@@ -46,7 +46,7 @@ namespace Intuit.TSheets.Model.Filters
         /// <param name="ids">
         /// The geolocation ids you'd like to filter on.
         /// </param>
-        public GeolocationFilter(IEnumerable<int> ids)
+        public GeolocationFilter(IEnumerable<long> ids)
         {
             Ids = ids;
         }
@@ -73,7 +73,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the filter for returning only those geolocations modified before this date/time.
@@ -95,7 +95,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("user_ids")]
-        public IEnumerable<int> UserIds { get; set; }
+        public IEnumerable<long> UserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the group ids to which only those linked geolocations will be returned.
@@ -103,6 +103,6 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("group_ids")]
-        public IEnumerable<int> GroupIds { get; set; }
+        public IEnumerable<long> GroupIds { get; set; }
     }
 }

--- a/Intuit.TSheets/Model/Filters/GroupFilter.cs
+++ b/Intuit.TSheets/Model/Filters/GroupFilter.cs
@@ -40,7 +40,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the value for filtering by active or inactive state, or both.
@@ -55,7 +55,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("manager_ids")]
-        public IEnumerable<int> ManagerIds { get; set; }
+        public IEnumerable<long> ManagerIds { get; set; }
 
         /// <summary>
         /// Gets or sets the group names you'd like to filter on.

--- a/Intuit.TSheets/Model/Filters/JobcodeAssignmentFilter.cs
+++ b/Intuit.TSheets/Model/Filters/JobcodeAssignmentFilter.cs
@@ -40,7 +40,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("user_ids")]
-        public IEnumerable<int> UserIds { get; set; }
+        public IEnumerable<long> UserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the value for filtering by jobcode type, e.g. 'regular', 'PTO', etc.
@@ -53,7 +53,7 @@ namespace Intuit.TSheets.Model.Filters
         /// Gets or sets the jobcode ids you'd like to filter on.
         /// </summary>
         [JsonProperty("jobcode_id")]
-        public int? JobcodeId { get; set; }
+        public long? JobcodeId { get; set; }
 
         /// <summary>
         /// Gets or sets the jobcode parent id you'd like to filter on.
@@ -64,7 +64,7 @@ namespace Intuit.TSheets.Model.Filters
         /// To get a list of only top-level jobcode assignments, pass in a jobcode_parent_id of 0.
         /// </remarks>
         [JsonProperty("jobcode_parent_id")]
-        public int? JobcodeParentId { get; set; }
+        public long? JobcodeParentId { get; set; }
 
         /// <summary>
         /// Gets or sets the value for filtering by active or inactive state, or both.

--- a/Intuit.TSheets/Model/Filters/JobcodeFilter.cs
+++ b/Intuit.TSheets/Model/Filters/JobcodeFilter.cs
@@ -40,7 +40,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the jobcode parent ids you'd like to filter on.
@@ -48,7 +48,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("parent_ids")]
-        public IEnumerable<int> ParentIds { get; set; }
+        public IEnumerable<long> ParentIds { get; set; }
 
         /// <summary>
         /// Gets or sets the wildcard-able filter on the jobcode name.

--- a/Intuit.TSheets/Model/Filters/LocationFilter.cs
+++ b/Intuit.TSheets/Model/Filters/LocationFilter.cs
@@ -43,7 +43,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the value for filtering by active or inactive state, or both.

--- a/Intuit.TSheets/Model/Filters/LocationsMapFilter.cs
+++ b/Intuit.TSheets/Model/Filters/LocationsMapFilter.cs
@@ -43,7 +43,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the value for filtering by active or inactive state, or both.

--- a/Intuit.TSheets/Model/Filters/NotificationFilter.cs
+++ b/Intuit.TSheets/Model/Filters/NotificationFilter.cs
@@ -38,7 +38,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the filter for returning only those notifications with a delivery data before this date/time.
@@ -58,7 +58,7 @@ namespace Intuit.TSheets.Model.Filters
         /// Gets or sets the user id for filtering results only to those notifications linked.
         /// </summary>
         [JsonProperty("user_id")]
-        public int? UserId { get; set; }
+        public long? UserId { get; set; }
 
         /// <summary>
         /// Gets or sets the value for filtering by the tracking ID string of a notification. Only those notifications with this message tracking id will be returned.

--- a/Intuit.TSheets/Model/Filters/PayrollByJobcodeReportFilter.cs
+++ b/Intuit.TSheets/Model/Filters/PayrollByJobcodeReportFilter.cs
@@ -75,7 +75,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("user_ids")]
-        public IEnumerable<int> UserIds { get; set; }
+        public IEnumerable<long> UserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the group ids you'd like to filter on.
@@ -83,7 +83,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("group_ids")]
-        public IEnumerable<int> GroupIds { get; set; }
+        public IEnumerable<long> GroupIds { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether to format report results such that it includes the time for individual multipliers and can support more than just 1.5x (OT) and 2x (dt) overtime.

--- a/Intuit.TSheets/Model/Filters/PayrollReportFilter.cs
+++ b/Intuit.TSheets/Model/Filters/PayrollReportFilter.cs
@@ -75,7 +75,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("user_ids")]
-        public IEnumerable<int> UserIds { get; set; }
+        public IEnumerable<long> UserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the group ids you'd like to filter on.
@@ -83,7 +83,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("group_ids")]
-        public IEnumerable<int> GroupIds { get; set; }
+        public IEnumerable<long> GroupIds { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether to include all users in the report, even if they had zero hours for the time period.

--- a/Intuit.TSheets/Model/Filters/ProjectReportFilter.cs
+++ b/Intuit.TSheets/Model/Filters/ProjectReportFilter.cs
@@ -77,7 +77,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("user_ids")]
-        public IEnumerable<int> UserIds { get; set; }
+        public IEnumerable<long> UserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the group ids you'd like to filter on.
@@ -85,7 +85,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("group_ids")]
-        public IEnumerable<int> GroupIds { get; set; }
+        public IEnumerable<long> GroupIds { get; set; }
 
         /// <summary>
         /// Gets or sets the jobcode ids you'd like to filter on.
@@ -93,7 +93,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("jobcode_ids")]
-        public IEnumerable<int> JobcodeIds { get; set; }
+        public IEnumerable<long> JobcodeIds { get; set; }
 
         /// <summary>
         /// Gets or sets the jobcode types you'd like to filter on.

--- a/Intuit.TSheets/Model/Filters/ReminderFilter.cs
+++ b/Intuit.TSheets/Model/Filters/ReminderFilter.cs
@@ -43,7 +43,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("user_ids")]
-        public IEnumerable<int> UserIds { get; set; }
+        public IEnumerable<long> UserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the reminder types you'd like to filter on.

--- a/Intuit.TSheets/Model/Filters/ScheduleCalendarFilter.cs
+++ b/Intuit.TSheets/Model/Filters/ScheduleCalendarFilter.cs
@@ -38,7 +38,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the filter for returning only those schedule calendars modified before this date/time.

--- a/Intuit.TSheets/Model/Filters/ScheduleEventFilter.cs
+++ b/Intuit.TSheets/Model/Filters/ScheduleEventFilter.cs
@@ -51,7 +51,7 @@ namespace Intuit.TSheets.Model.Filters
         /// <param name="scheduleCalendarIds">
         /// The schedule calendar ids you'd like to filter on.
         /// </param>
-        public ScheduleEventFilter(IEnumerable<int> ids, IEnumerable<int> scheduleCalendarIds)
+        public ScheduleEventFilter(IEnumerable<long> ids, IEnumerable<long> scheduleCalendarIds)
         {
             Ids = ids;
             ScheduleCalendarIds = scheduleCalendarIds;
@@ -70,7 +70,7 @@ namespace Intuit.TSheets.Model.Filters
         /// <param name="scheduleCalendarIds">
         /// The schedule calendar ids you'd like to filter on.
         /// </param>
-        public ScheduleEventFilter(DateTimeOffset modifiedSince, DateTimeOffset modifiedBefore, IEnumerable<int> scheduleCalendarIds)
+        public ScheduleEventFilter(DateTimeOffset modifiedSince, DateTimeOffset modifiedBefore, IEnumerable<long> scheduleCalendarIds)
         {
             ModifiedSince = modifiedSince;
             ModifiedBefore = modifiedBefore;
@@ -87,7 +87,7 @@ namespace Intuit.TSheets.Model.Filters
         /// <param name="scheduleCalendarIds">
         /// The schedule calendar ids you'd like to filter on.
         /// </param>
-        public ScheduleEventFilter(DateTimeOffset start, IEnumerable<int> scheduleCalendarIds)
+        public ScheduleEventFilter(DateTimeOffset start, IEnumerable<long> scheduleCalendarIds)
         {
             Start = start;
             ScheduleCalendarIds = scheduleCalendarIds;
@@ -99,7 +99,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the user ids you'd like to filter on.
@@ -107,7 +107,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("user_ids")]
-        public IEnumerable<int> UserIds { get; set; }
+        public IEnumerable<long> UserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the schedule calendar ids you'd like to filter on.
@@ -118,7 +118,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("schedule_calendar_ids")]
-        public IEnumerable<int> ScheduleCalendarIds { get; set; }
+        public IEnumerable<long> ScheduleCalendarIds { get; set; }
 
         /// <summary>
         /// Gets or sets the jobcode ids you'd like to filter on. Only schedule events with these jobcodes will be returned.
@@ -126,7 +126,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("jobcode_ids")]
-        public IEnumerable<int> JobcodeIds { get; set; }
+        public IEnumerable<long> JobcodeIds { get; set; }
 
         /// <summary>
         /// Gets or sets the value for filtering schedule events to a date range start.

--- a/Intuit.TSheets/Model/Filters/TimesheetFilter.cs
+++ b/Intuit.TSheets/Model/Filters/TimesheetFilter.cs
@@ -48,7 +48,7 @@ namespace Intuit.TSheets.Model.Filters
         /// <param name="ids">
         /// The timesheet ids you'd like to filter on.
         /// </param>
-        public TimesheetFilter(IEnumerable<int> ids)
+        public TimesheetFilter(IEnumerable<long> ids)
         {
             Ids = ids;
         }
@@ -95,7 +95,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the value for filtering timesheets to a date range start.
@@ -117,7 +117,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("jobcode_ids")]
-        public IEnumerable<int> JobcodeIds { get; set; }
+        public IEnumerable<long> JobcodeIds { get; set; }
 
         /// <summary>
         /// Gets or sets the payroll ids you'd like to filter on. Only time recorded against users with these payroll ids will be returned.
@@ -125,7 +125,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("payroll_ids")]
-        public IEnumerable<int> PayrollIds { get; set; }
+        public IEnumerable<long> PayrollIds { get; set; }
 
         /// <summary>
         /// Gets or sets the user ids you'd like to filter on. Only timesheets linked to these users will be returned.
@@ -133,7 +133,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("user_ids")]
-        public IEnumerable<int> UserIds { get; set; }
+        public IEnumerable<long> UserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the group ids you'd like to filter on. Only timesheets linked to users from these groups will be returned.
@@ -141,7 +141,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("group_ids")]
-        public IEnumerable<int> GroupIds { get; set; }
+        public IEnumerable<long> GroupIds { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating filtering by users who are on or off the clock, or both.

--- a/Intuit.TSheets/Model/Filters/TimesheetsDeletedFilter.cs
+++ b/Intuit.TSheets/Model/Filters/TimesheetsDeletedFilter.cs
@@ -48,7 +48,7 @@ namespace Intuit.TSheets.Model.Filters
         /// <param name="ids">
         /// The deleted timesheet ids you'd like to filter on.
         /// </param>
-        public TimesheetsDeletedFilter(IEnumerable<int> ids)
+        public TimesheetsDeletedFilter(IEnumerable<long> ids)
         {
             Ids = ids;
         }
@@ -109,7 +109,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the filter for returning only those deleted timesheets after before this date/time.
@@ -131,7 +131,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("group_ids")]
-        public IEnumerable<int> GroupIds { get; set; }
+        public IEnumerable<long> GroupIds { get; set; }
 
         /// <summary>
         /// Gets or sets the user ids you'd like to filter on. Only deleted timesheets linked these users will be returned.
@@ -139,7 +139,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("user_ids")]
-        public IEnumerable<int> UserIds { get; set; }
+        public IEnumerable<long> UserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the value for filter results to a specific username.
@@ -156,7 +156,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("jobcode_ids")]
-        public IEnumerable<int> JobcodeIds { get; set; }
+        public IEnumerable<long> JobcodeIds { get; set; }
 
         /// <summary>
         /// Gets or sets the jobcode type you'd like to filter on.

--- a/Intuit.TSheets/Model/Filters/UserFilter.cs
+++ b/Intuit.TSheets/Model/Filters/UserFilter.cs
@@ -40,7 +40,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)] 
         [JsonProperty("ids")]
-        public IEnumerable<int> Ids { get; set; }
+        public IEnumerable<long> Ids { get; set; }
 
         /// <summary>
         /// Gets or sets the ids you'd like to exclude.
@@ -48,7 +48,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("not_ids")]
-        public IEnumerable<int> NotIds { get; set; }
+        public IEnumerable<long> NotIds { get; set; }
 
         /// <summary>
         /// Gets or sets the employee numbers you'd like to filter on.
@@ -56,7 +56,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("employee_numbers")]
-        public IEnumerable<int> EmployeeNumbers { get; set; }
+        public IEnumerable<long> EmployeeNumbers { get; set; }
 
         /// <summary>
         /// Gets or sets the user names you'd like to filter on.
@@ -72,7 +72,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("group_ids")]
-        public IEnumerable<int> GroupIds { get; set; }
+        public IEnumerable<long> GroupIds { get; set; }
 
         /// <summary>
         /// Gets or sets the group ids you'd like to exclude.
@@ -80,7 +80,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("not_group_ids")]
-        public IEnumerable<int> NotGroupIds { get; set; }
+        public IEnumerable<long> NotGroupIds { get; set; }
 
         /// <summary>
         /// Gets or sets the payroll ids you'd like to filter on. Only users with these payroll ids will be returned.
@@ -88,7 +88,7 @@ namespace Intuit.TSheets.Model.Filters
         [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonSchema(JsonObjectType.String)]
         [JsonProperty("payroll_ids")]
-        public IEnumerable<int> PayrollIds { get; set; }
+        public IEnumerable<long> PayrollIds { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether to filter by active or inactive state, or both.

--- a/Intuit.TSheets/Model/GeofenceConfig.cs
+++ b/Intuit.TSheets/Model/GeofenceConfig.cs
@@ -38,7 +38,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets the type of entity the geofence config is related to.
@@ -54,7 +54,7 @@ namespace Intuit.TSheets.Model
         /// Gets the id of the entity the geofence config is related to.
         /// </summary>
         [JsonProperty("type_id")]
-        public int? TypeId { get; internal set; }
+        public long? TypeId { get; internal set; }
 
         /// <summary>
         /// Gets the status of this geofence config.

--- a/Intuit.TSheets/Model/Geolocation.cs
+++ b/Intuit.TSheets/Model/Geolocation.cs
@@ -53,7 +53,7 @@ namespace Intuit.TSheets.Model
         /// <param name="longitude">The longitude of the geolocation in degrees.</param>
         public Geolocation(
             DateTimeOffset created,
-            int userId,
+            long userId,
             float accuracy,
             float altitude,
             float latitude,
@@ -72,13 +72,13 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the id for the user that this geolocation belongs to.
         /// </summary>
         [JsonProperty("user_id")]
-        public int? UserId { get; set; }
+        public long? UserId { get; set; }
 
         /// <summary>
         /// Gets or sets the radius of accuracy around the geolocation in meters.

--- a/Intuit.TSheets/Model/Group.cs
+++ b/Intuit.TSheets/Model/Group.cs
@@ -56,7 +56,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate] 
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether this group is active or archived.
@@ -74,7 +74,7 @@ namespace Intuit.TSheets.Model
         /// Gets or sets the list of id's of the users allowed to manage this group.
         /// </summary>
         [JsonProperty("manager_ids")]
-        public IList<int> ManagerIds { get; set; }
+        public IList<long> ManagerIds { get; set; }
 
         /// <summary>
         /// Gets the date/time when this group was created.

--- a/Intuit.TSheets/Model/IIdentifiable.cs
+++ b/Intuit.TSheets/Model/IIdentifiable.cs
@@ -32,6 +32,6 @@ namespace Intuit.TSheets.Model
         /// <summary>
         /// Gets the item's identifier value
         /// </summary>
-        int Id { get; }
+        long Id { get; }
     }
 }

--- a/Intuit.TSheets/Model/Invitation.cs
+++ b/Intuit.TSheets/Model/Invitation.cs
@@ -51,7 +51,7 @@ namespace Intuit.TSheets.Model
         /// <param name="userId">
         /// The id of the user for which the invitation is to be sent.
         /// </param>
-        public Invitation(InvitationContactMethod contactMethod, string contactInfo, int userId)
+        public Invitation(InvitationContactMethod contactMethod, string contactInfo, long userId)
         {
             ContactMethod = contactMethod;
             ContactInfo = contactInfo;
@@ -81,6 +81,6 @@ namespace Intuit.TSheets.Model
         /// Gets or sets the id of the user for which the invitation is to be sent.
         /// </summary>
         [JsonProperty("user_id")]
-        public int UserId { get; set; }
+        public long UserId { get; set; }
     }
 }

--- a/Intuit.TSheets/Model/Jobcode.cs
+++ b/Intuit.TSheets/Model/Jobcode.cs
@@ -58,7 +58,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the id of the parent of this jobcode.
@@ -67,7 +67,7 @@ namespace Intuit.TSheets.Model
         /// Value is 0 if jobcode is top-level.
         /// </remarks>
         [JsonProperty("parent_id")]
-        public int? ParentId { get; set; }
+        public long? ParentId { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the jobcode.
@@ -141,7 +141,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnWrite]
         [JsonProperty("required_customfields")]
-        public IReadOnlyList<int> RequiredCustomFields { get; internal set; }
+        public IReadOnlyList<long> RequiredCustomFields { get; internal set; }
 
         /// <summary>
         /// Gets the custom field items that are to be displayed when this jobcode is chosen for a timesheet.
@@ -152,7 +152,7 @@ namespace Intuit.TSheets.Model
         /// </remarks>
         [NoSerializeOnWrite]
         [JsonProperty("filtered_customfielditems")]
-        public IReadOnlyDictionary<string, IReadOnlyList<int>> FilteredCustomFieldItems { get; internal set; }
+        public IReadOnlyDictionary<string, IReadOnlyList<long>> FilteredCustomFieldItems { get; internal set; }
 
         /// <summary>
         /// Gets or sets the status of the jobcode.
@@ -186,13 +186,13 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnWrite]
         [JsonProperty("locations")]
-        public IReadOnlyList<int> Locations { get; internal set; }
+        public IReadOnlyList<long> Locations { get; internal set; }
 
         /// <summary>
         /// Gets the id of the project.
         /// </summary>
         [JsonProperty("project_id")]
-        public int? ProjectId { get; internal set; }
+        public long? ProjectId { get; internal set; }
 
 
         /// <summary>

--- a/Intuit.TSheets/Model/JobcodeAssignment.cs
+++ b/Intuit.TSheets/Model/JobcodeAssignment.cs
@@ -49,7 +49,7 @@ namespace Intuit.TSheets.Model
         /// <param name="jobcodeId">
         /// The id of the jobcode to which this assignment pertains.
         /// </param> 
-        public JobcodeAssignment(int userId, int jobcodeId)
+        public JobcodeAssignment(long userId, long jobcodeId)
         {
             UserId = userId;
             JobcodeId = jobcodeId;
@@ -60,19 +60,19 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate] 
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the id of the user to which this assignment pertains.
         /// </summary>
         [JsonProperty("user_id")]
-        public int? UserId { get; set; }
+        public long? UserId { get; set; }
 
         /// <summary>
         /// Gets or sets the id of the jobcode that this assignment pertains to.
         /// </summary>
         [JsonProperty("jobcode_id")]
-        public int? JobcodeId { get; set; }
+        public long? JobcodeId { get; set; }
 
         /// <summary>
         /// Gets or sets the status of the jobcode assignment.

--- a/Intuit.TSheets/Model/Location.cs
+++ b/Intuit.TSheets/Model/Location.cs
@@ -78,7 +78,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the first line of the location's address.
@@ -209,6 +209,6 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnWrite]
         [JsonProperty("geofence_config_id")]
-        public int? GeofenceConfigId { get; internal set; }
+        public long? GeofenceConfigId { get; internal set; }
     }
 }

--- a/Intuit.TSheets/Model/LocationLinkedObjectIds.cs
+++ b/Intuit.TSheets/Model/LocationLinkedObjectIds.cs
@@ -32,6 +32,6 @@ namespace Intuit.TSheets.Model
         /// Gets or sets the jobcodes to which this location is linked.
         /// </summary>
         [JsonProperty("jobcodes")]
-        public IList<int> Jobcodes { get; set; }
+        public IList<long> Jobcodes { get; set; }
     }
 }

--- a/Intuit.TSheets/Model/LocationsMap.cs
+++ b/Intuit.TSheets/Model/LocationsMap.cs
@@ -37,7 +37,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets the name of the entity the location is mapped to.
@@ -53,13 +53,13 @@ namespace Intuit.TSheets.Model
         /// Gets the id of the entity the location is mapped to.
         /// </summary>
         [JsonProperty("x_id")]
-        public int? XId { get; internal set; }
+        public long? XId { get; internal set; }
 
         /// <summary>
         /// Gets the id of the location that is mapped to the entity.
         /// </summary>
         [JsonProperty("location_id")]
-        public int? LocationId { get; internal set; }
+        public long? LocationId { get; internal set; }
 
         /// <summary>
         /// Gets the date/time when this locations map was last modified.

--- a/Intuit.TSheets/Model/ManagedClient.cs
+++ b/Intuit.TSheets/Model/ManagedClient.cs
@@ -35,7 +35,7 @@ namespace Intuit.TSheets.Model
         /// Gets the id of the managed client.
         /// </summary>
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets the sub-domain portion of the company URL used by the managed client to sign in to TSheets.

--- a/Intuit.TSheets/Model/Notification.cs
+++ b/Intuit.TSheets/Model/Notification.cs
@@ -50,7 +50,7 @@ namespace Intuit.TSheets.Model
         /// <param name="message">
         /// The message text of the notification.
         /// </param>
-        public Notification(int userId, string message)
+        public Notification(long userId, string message)
         {
             UserId = userId;
             Message = message;
@@ -61,13 +61,13 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the id for the user that this notification will be sent to.
         /// </summary>
         [JsonProperty("user_id")]
-        public int? UserId { get; set; }
+        public long? UserId { get; set; }
 
         /// <summary>
         /// Gets the GUID string used for additional tracking.

--- a/Intuit.TSheets/Model/PayrollByJobcodeByUser.cs
+++ b/Intuit.TSheets/Model/PayrollByJobcodeByUser.cs
@@ -32,7 +32,7 @@ namespace Intuit.TSheets.Model
         ///  Gets the user id to which this report data pertains.
         /// </summary>
         [JsonProperty("user_id")]
-        public int UserId { get; internal set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// Gets the Payroll By Jobcode Totals for this User

--- a/Intuit.TSheets/Model/PayrollByJobcodeReportFilters.cs
+++ b/Intuit.TSheets/Model/PayrollByJobcodeReportFilters.cs
@@ -57,7 +57,7 @@ namespace Intuit.TSheets.Model
         /// Only time for these users will be included.
         /// </remarks>
         [JsonProperty("user_ids")]
-        public IReadOnlyList<int> UserIds { get; internal set; }
+        public IReadOnlyList<long> UserIds { get; internal set; }
 
         /// <summary>
         /// Gets the ids for groups to be included in the report.
@@ -66,7 +66,7 @@ namespace Intuit.TSheets.Model
         /// Only time for these groups will be included.
         /// </remarks>
         [JsonProperty("group_ids")]
-        public IReadOnlyList<int> GroupIds { get; internal set; }
+        public IReadOnlyList<long> GroupIds { get; internal set; }
 
         /// <summary>
         /// Gets the value indicating whether or not advanced overtime is enabled for the report.

--- a/Intuit.TSheets/Model/PayrollByJobcodeReportItem.cs
+++ b/Intuit.TSheets/Model/PayrollByJobcodeReportItem.cs
@@ -32,7 +32,7 @@ namespace Intuit.TSheets.Model
         ///  Gets the jobcode id to which this data pertains.
         /// </summary>
         [JsonProperty("jobcode_id")]
-        public int JobcodeId { get; internal set; }
+        public long JobcodeId { get; internal set; }
 
         /// <summary>
         /// Gets regular time, in seconds 

--- a/Intuit.TSheets/Model/PayrollReportItem.cs
+++ b/Intuit.TSheets/Model/PayrollReportItem.cs
@@ -34,13 +34,13 @@ namespace Intuit.TSheets.Model
         /// Gets the user id to which this payroll data pertains.
         /// </summary>
         [JsonProperty("user_id")]
-        public int UserId { get; internal set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// Gets the client id to which this payroll data pertains.
         /// </summary>
         [JsonProperty("client_id")]
-        public int ClientId { get; internal set; }
+        public long ClientId { get; internal set; }
 
         /// <summary> 
         /// Gets start of the reporting time frame.

--- a/Intuit.TSheets/Model/ProjectReportFilters.cs
+++ b/Intuit.TSheets/Model/ProjectReportFilters.cs
@@ -39,7 +39,7 @@ namespace Intuit.TSheets.Model
         /// Only time for these users will be included.
         /// </remarks>
         [JsonProperty("user_ids")]
-        public IReadOnlyList<int> UserIds { get; internal set; }
+        public IReadOnlyList<long> UserIds { get; internal set; }
 
         /// <summary>
         /// Gets filter for the ids for <see cref="Group"/> objects to be included in the report.
@@ -48,7 +48,7 @@ namespace Intuit.TSheets.Model
         /// Only time for these groups will be included.
         /// </remarks>
         [JsonProperty("group_ids")]
-        public IReadOnlyList<int> GroupIds { get; internal set; }
+        public IReadOnlyList<long> GroupIds { get; internal set; }
 
         /// <summary>
         /// Gets filter for the start date for the report.
@@ -77,7 +77,7 @@ namespace Intuit.TSheets.Model
         /// Only time for these jobcodes will be included.
         /// </remarks>
         [JsonProperty("jobcode_ids")]
-        public IReadOnlyList<int> JobcodeIds { get; internal set; }
+        public IReadOnlyList<long> JobcodeIds { get; internal set; }
 
         /// <summary>
         /// Gets filters for the <see cref="CustomFieldItems"/> objects to be included in the report.

--- a/Intuit.TSheets/Model/ProjectReportTotals.cs
+++ b/Intuit.TSheets/Model/ProjectReportTotals.cs
@@ -32,24 +32,24 @@ namespace Intuit.TSheets.Model
         /// Gets User Report Totals
         /// </summary>
         [JsonProperty("users")]
-        public IReadOnlyDictionary<int, float> Users { get; internal set; }
+        public IReadOnlyDictionary<long, float> Users { get; internal set; }
 
         /// <summary>
         /// Gets Group Report Totals
         /// </summary>
         [JsonProperty("groups")]
-        public IReadOnlyDictionary<int, float> Groups { get; internal set; }
+        public IReadOnlyDictionary<long, float> Groups { get; internal set; }
 
         /// <summary>
         /// Gets Jobcode Report Totals
         /// </summary>
         [JsonProperty("jobcodes")]
-        public IReadOnlyDictionary<int, float> Jobcodes { get; internal set; }
+        public IReadOnlyDictionary<long, float> Jobcodes { get; internal set; }
 
         /// <summary>
         /// Gets Custom Field Report Totals
         /// </summary>
         [JsonProperty("customfields")]
-        public IReadOnlyDictionary<int, IReadOnlyDictionary<int, float>> CustomFields { get; internal set; }
+        public IReadOnlyDictionary<long, IReadOnlyDictionary<long, float>> CustomFields { get; internal set; }
     }
 }

--- a/Intuit.TSheets/Model/Reminder.cs
+++ b/Intuit.TSheets/Model/Reminder.cs
@@ -75,7 +75,7 @@ namespace Intuit.TSheets.Model
         /// receive that reminder type regardless of how company-wide reminders are configured.
         /// </param>
         public Reminder(
-            int userId,
+            long userId,
             ReminderTypes reminderType,
             DateTimeOffset dueTime,
             DaysOfTheWeek dueDaysOfWeek,
@@ -97,7 +97,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets id of the user that this reminder pertains to.
@@ -106,7 +106,7 @@ namespace Intuit.TSheets.Model
         /// A value of 0 indicates that this is a company-wide reminder.
         /// </remarks>
         [JsonProperty("user_id")]
-        public int? UserId { get; internal set; }
+        public long? UserId { get; internal set; }
 
         /// <summary>
         /// Gets or sets the type of this reminder object.

--- a/Intuit.TSheets/Model/ScheduleCalendar.cs
+++ b/Intuit.TSheets/Model/ScheduleCalendar.cs
@@ -35,7 +35,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets the name of the schedule calendar.

--- a/Intuit.TSheets/Model/ScheduleEvent.cs
+++ b/Intuit.TSheets/Model/ScheduleEvent.cs
@@ -58,7 +58,7 @@ namespace Intuit.TSheets.Model
         /// The value indicating whether or not the event is all-day.
         /// </param>
         public ScheduleEvent(
-            int scheduleCalendarId,
+            long scheduleCalendarId,
             DateTimeOffset start,
             DateTimeOffset end,
             bool allDay)
@@ -74,13 +74,13 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the id of the calendar that contains this schedule event.
         /// </summary>
         [JsonProperty("schedule_calendar_id")]
-        public int? ScheduleCalendarId { get; set; }
+        public long? ScheduleCalendarId { get; set; }
 
         /// <summary>
         /// Gets or sets the date/time that represents the start time of this schedule event.
@@ -115,7 +115,7 @@ namespace Intuit.TSheets.Model
         /// </remarks>
         [NoSerializeOnWrite]
         [JsonProperty("user_id")]
-        public int? UserId { get; internal set; }
+        public long? UserId { get; internal set; }
 
         /// <summary>
         /// Gets the value indicating Whether or not the schedule event is assigned.
@@ -135,15 +135,14 @@ namespace Intuit.TSheets.Model
         /// Empty if the event is unassigned. Changing the assigned user IDs of
         /// an event may result in multiple event modifications.
         /// </remarks>
-        [JsonConverter(typeof(EnumerableToCsvConverter))]
         [JsonProperty("assigned_user_ids")]
-        public IList<int> AssignedUserIds { get; set; }
+        public IList<long> AssignedUserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the id of the jobcode associated with this event.
         /// </summary>
         [JsonProperty("jobcode_id")]
-        public int? JobcodeId { get; set; }
+        public long? JobcodeId { get; set; }
 
         /// <summary>
         /// Gets or sets the status of the schedule event.

--- a/Intuit.TSheets/Model/Schemas/CurrentTotalsReport.xsd
+++ b/Intuit.TSheets/Model/Schemas/CurrentTotalsReport.xsd
@@ -31,22 +31,22 @@
       "properties": {
         "user_id": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "on_the_clock": {
           "type": "boolean"
         },
         "timesheet_id": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "jobcode_id": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "group_id": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "shift_geolocations_available": {
           "type": "boolean"

--- a/Intuit.TSheets/Model/Schemas/CurrentTotalsReportItem.xsd
+++ b/Intuit.TSheets/Model/Schemas/CurrentTotalsReportItem.xsd
@@ -16,22 +16,22 @@
   "properties": {
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "on_the_clock": {
       "type": "boolean"
     },
     "timesheet_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "jobcode_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "group_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "shift_geolocations_available": {
       "type": "boolean"

--- a/Intuit.TSheets/Model/Schemas/CustomField.xsd
+++ b/Intuit.TSheets/Model/Schemas/CustomField.xsd
@@ -21,7 +21,7 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "active": {
       "type": "boolean"
@@ -62,7 +62,7 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     }
   },

--- a/Intuit.TSheets/Model/Schemas/CustomFieldItem.xsd
+++ b/Intuit.TSheets/Model/Schemas/CustomFieldItem.xsd
@@ -15,11 +15,11 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "customfield_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "name": {
       "type": "string"
@@ -38,7 +38,7 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     }
   }

--- a/Intuit.TSheets/Model/Schemas/CustomFieldItemFilter.xsd
+++ b/Intuit.TSheets/Model/Schemas/CustomFieldItemFilter.xsd
@@ -15,22 +15,22 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "customfield_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "customfielditem_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "applies_to": {
       "$ref": "#/definitions/FilterAppliesTo"
     },
     "applies_to_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "active": {
       "type": "boolean"

--- a/Intuit.TSheets/Model/Schemas/CustomFieldItemJobcodeFilter.xsd
+++ b/Intuit.TSheets/Model/Schemas/CustomFieldItemJobcodeFilter.xsd
@@ -11,7 +11,7 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "last_modified": {
       "type": "string",
@@ -23,7 +23,7 @@
         "type": "array",
         "items": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         }
       }
     }

--- a/Intuit.TSheets/Model/Schemas/CustomFieldItemUserFilter.xsd
+++ b/Intuit.TSheets/Model/Schemas/CustomFieldItemUserFilter.xsd
@@ -12,7 +12,7 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "type": {
       "$ref": "#/definitions/UserFilterType"
@@ -27,7 +27,7 @@
         "type": "array",
         "items": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         }
       }
     }

--- a/Intuit.TSheets/Model/Schemas/File.xsd
+++ b/Intuit.TSheets/Model/Schemas/File.xsd
@@ -18,7 +18,7 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "file_name": {
       "type": "string"
@@ -28,7 +28,7 @@
     },
     "uploaded_by_user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "active": {
       "type": "boolean"
@@ -64,7 +64,7 @@
           "type": "array",
           "items": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         }
       }

--- a/Intuit.TSheets/Model/Schemas/FileLinkedObjectIds.xsd
+++ b/Intuit.TSheets/Model/Schemas/FileLinkedObjectIds.xsd
@@ -11,7 +11,7 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     }
   }

--- a/Intuit.TSheets/Model/Schemas/Filters/CustomFieldItemFilter.xsd
+++ b/Intuit.TSheets/Model/Schemas/Filters/CustomFieldItemFilter.xsd
@@ -13,7 +13,7 @@
   "properties": {
     "customfield_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "ids": {
       "type": "string"

--- a/Intuit.TSheets/Model/Schemas/Filters/CustomFieldItemFilterFilter.xsd
+++ b/Intuit.TSheets/Model/Schemas/Filters/CustomFieldItemFilterFilter.xsd
@@ -17,15 +17,15 @@
   "properties": {
     "jobcode_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "group_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "include_user_group": {
       "type": "boolean"

--- a/Intuit.TSheets/Model/Schemas/Filters/CustomFieldItemJobcodeFilterFilter.xsd
+++ b/Intuit.TSheets/Model/Schemas/Filters/CustomFieldItemJobcodeFilterFilter.xsd
@@ -11,7 +11,7 @@
   "properties": {
     "jobcode_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "modified_before": {
       "type": "string",

--- a/Intuit.TSheets/Model/Schemas/Filters/CustomFieldItemUserFilterFilter.xsd
+++ b/Intuit.TSheets/Model/Schemas/Filters/CustomFieldItemUserFilterFilter.xsd
@@ -13,11 +13,11 @@
   "properties": {
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "group_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "include_user_group": {
       "type": "boolean"

--- a/Intuit.TSheets/Model/Schemas/Filters/EffectiveSettingsFilter.xsd
+++ b/Intuit.TSheets/Model/Schemas/Filters/EffectiveSettingsFilter.xsd
@@ -11,7 +11,7 @@
   "properties": {
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "modified_before": {
       "type": "string",

--- a/Intuit.TSheets/Model/Schemas/Filters/JobcodeAssignmentFilter.xsd
+++ b/Intuit.TSheets/Model/Schemas/Filters/JobcodeAssignmentFilter.xsd
@@ -21,11 +21,11 @@
     },
     "jobcode_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "jobcode_parent_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "active": {
       "$ref": "#/definitions/TristateChoice"

--- a/Intuit.TSheets/Model/Schemas/Filters/NotificationFilter.xsd
+++ b/Intuit.TSheets/Model/Schemas/Filters/NotificationFilter.xsd
@@ -24,7 +24,7 @@
     },
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "msg_tracking_id": {
       "type": "string"

--- a/Intuit.TSheets/Model/Schemas/GeofenceConfig.xsd
+++ b/Intuit.TSheets/Model/Schemas/GeofenceConfig.xsd
@@ -16,14 +16,14 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "type": {
       "$ref": "#/definitions/GeofenceConfigType"
     },
     "type_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "active": {
       "type": "boolean"

--- a/Intuit.TSheets/Model/Schemas/Geolocation.xsd
+++ b/Intuit.TSheets/Model/Schemas/Geolocation.xsd
@@ -19,11 +19,11 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "accuracy": {
       "type": "number",

--- a/Intuit.TSheets/Model/Schemas/Group.xsd
+++ b/Intuit.TSheets/Model/Schemas/Group.xsd
@@ -14,7 +14,7 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "active": {
       "type": "boolean"
@@ -26,7 +26,7 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     },
     "created": {

--- a/Intuit.TSheets/Model/Schemas/Invitation.xsd
+++ b/Intuit.TSheets/Model/Schemas/Invitation.xsd
@@ -17,7 +17,7 @@
     },
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     }
   },
   "definitions": {

--- a/Intuit.TSheets/Model/Schemas/Jobcode.xsd
+++ b/Intuit.TSheets/Model/Schemas/Jobcode.xsd
@@ -25,11 +25,11 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "parent_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "name": {
       "type": "string"
@@ -57,7 +57,7 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     },
     "filtered_customfielditems": {
@@ -66,7 +66,7 @@
         "type": "array",
         "items": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         }
       }
     },
@@ -85,12 +85,12 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     },
     "project_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "connect_with_quickbooks": {
       "type": "boolean"

--- a/Intuit.TSheets/Model/Schemas/JobcodeAssignment.xsd
+++ b/Intuit.TSheets/Model/Schemas/JobcodeAssignment.xsd
@@ -14,15 +14,15 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "jobcode_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "active": {
       "type": "boolean"

--- a/Intuit.TSheets/Model/Schemas/Location.xsd
+++ b/Intuit.TSheets/Model/Schemas/Location.xsd
@@ -27,7 +27,7 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "addr1": {
       "type": "string"
@@ -86,7 +86,7 @@
     },
     "geofence_config_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     }
   },
   "definitions": {
@@ -119,7 +119,7 @@
           "type": "array",
           "items": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         }
       }

--- a/Intuit.TSheets/Model/Schemas/LocationLinkedObjectIds.xsd
+++ b/Intuit.TSheets/Model/Schemas/LocationLinkedObjectIds.xsd
@@ -11,7 +11,7 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     }
   }

--- a/Intuit.TSheets/Model/Schemas/LocationsMap.xsd
+++ b/Intuit.TSheets/Model/Schemas/LocationsMap.xsd
@@ -14,18 +14,18 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "x_table": {
       "$ref": "#/definitions/LocationsMapXTableType"
     },
     "x_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "location_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "last_modified": {
       "type": "string",

--- a/Intuit.TSheets/Model/Schemas/ManagedClient.xsd
+++ b/Intuit.TSheets/Model/Schemas/ManagedClient.xsd
@@ -14,7 +14,7 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "company_url": {
       "type": "string"

--- a/Intuit.TSheets/Model/Schemas/Notification.xsd
+++ b/Intuit.TSheets/Model/Schemas/Notification.xsd
@@ -16,11 +16,11 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "msg_tracking_id": {
       "type": "string"

--- a/Intuit.TSheets/Model/Schemas/PayrollByJobcodeByUser.xsd
+++ b/Intuit.TSheets/Model/Schemas/PayrollByJobcodeByUser.xsd
@@ -11,7 +11,7 @@
   "properties": {
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "totals": {
       "type": "object",
@@ -46,7 +46,7 @@
       "properties": {
         "jobcode_id": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "total_re_seconds": {
           "type": "integer",

--- a/Intuit.TSheets/Model/Schemas/PayrollByJobcodeReport.xsd
+++ b/Intuit.TSheets/Model/Schemas/PayrollByJobcodeReport.xsd
@@ -39,14 +39,14 @@
           "type": "array",
           "items": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         },
         "group_ids": {
           "type": "array",
           "items": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         },
         "advanced_overtime": {
@@ -92,7 +92,7 @@
       "properties": {
         "jobcode_id": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "total_re_seconds": {
           "type": "integer",
@@ -141,7 +141,7 @@
       "properties": {
         "user_id": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "totals": {
           "type": "object",

--- a/Intuit.TSheets/Model/Schemas/PayrollByJobcodeReportData.xsd
+++ b/Intuit.TSheets/Model/Schemas/PayrollByJobcodeReportData.xsd
@@ -38,7 +38,7 @@
       "properties": {
         "jobcode_id": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "total_re_seconds": {
           "type": "integer",
@@ -87,7 +87,7 @@
       "properties": {
         "user_id": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "totals": {
           "type": "object",

--- a/Intuit.TSheets/Model/Schemas/PayrollByJobcodeReportFilters.xsd
+++ b/Intuit.TSheets/Model/Schemas/PayrollByJobcodeReportFilters.xsd
@@ -23,14 +23,14 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     },
     "group_ids": {
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     },
     "advanced_overtime": {

--- a/Intuit.TSheets/Model/Schemas/PayrollByJobcodeReportItem.xsd
+++ b/Intuit.TSheets/Model/Schemas/PayrollByJobcodeReportItem.xsd
@@ -16,7 +16,7 @@
   "properties": {
     "jobcode_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "total_re_seconds": {
       "type": "integer",

--- a/Intuit.TSheets/Model/Schemas/PayrollReport.xsd
+++ b/Intuit.TSheets/Model/Schemas/PayrollReport.xsd
@@ -33,11 +33,11 @@
       "properties": {
         "user_id": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "client_id": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         },
         "start_date": {
           "type": "string",

--- a/Intuit.TSheets/Model/Schemas/PayrollReportItem.xsd
+++ b/Intuit.TSheets/Model/Schemas/PayrollReportItem.xsd
@@ -18,11 +18,11 @@
   "properties": {
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "client_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "start_date": {
       "type": "string",

--- a/Intuit.TSheets/Model/Schemas/ProjectReport.xsd
+++ b/Intuit.TSheets/Model/Schemas/ProjectReport.xsd
@@ -45,14 +45,14 @@
           "type": "array",
           "items": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         },
         "group_ids": {
           "type": "array",
           "items": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         },
         "start_date": {
@@ -67,7 +67,7 @@
           "type": "array",
           "items": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         },
         "customfielditems": {

--- a/Intuit.TSheets/Model/Schemas/ProjectReportData.xsd
+++ b/Intuit.TSheets/Model/Schemas/ProjectReportData.xsd
@@ -33,14 +33,14 @@
           "type": "array",
           "items": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         },
         "group_ids": {
           "type": "array",
           "items": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         },
         "start_date": {
@@ -55,7 +55,7 @@
           "type": "array",
           "items": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           }
         },
         "customfielditems": {

--- a/Intuit.TSheets/Model/Schemas/ProjectReportFilters.xsd
+++ b/Intuit.TSheets/Model/Schemas/ProjectReportFilters.xsd
@@ -17,14 +17,14 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     },
     "group_ids": {
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     },
     "start_date": {
@@ -39,7 +39,7 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     },
     "customfielditems": {

--- a/Intuit.TSheets/Model/Schemas/Reminder.xsd
+++ b/Intuit.TSheets/Model/Schemas/Reminder.xsd
@@ -18,11 +18,11 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "reminder_type": {
       "$ref": "#/definitions/ReminderTypes"

--- a/Intuit.TSheets/Model/Schemas/ScheduleCalendar.xsd
+++ b/Intuit.TSheets/Model/Schemas/ScheduleCalendar.xsd
@@ -12,7 +12,7 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "name": {
       "type": "string"

--- a/Intuit.TSheets/Model/Schemas/ScheduleEvent.xsd
+++ b/Intuit.TSheets/Model/Schemas/ScheduleEvent.xsd
@@ -27,11 +27,11 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "schedule_calendar_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "start": {
       "type": "string",
@@ -46,17 +46,21 @@
     },
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "unassigned": {
       "type": "boolean"
     },
     "assigned_user_ids": {
-      "type": "string"
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "int64"
+      }
     },
     "jobcode_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "active": {
       "type": "boolean"

--- a/Intuit.TSheets/Model/Schemas/Timesheet.xsd
+++ b/Intuit.TSheets/Model/Schemas/Timesheet.xsd
@@ -24,15 +24,15 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "jobcode_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "locked": {
       "type": "integer",
@@ -61,12 +61,12 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     },
     "created_by_user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "duration": {
       "type": "integer",

--- a/Intuit.TSheets/Model/Schemas/TimesheetsDeleted.xsd
+++ b/Intuit.TSheets/Model/Schemas/TimesheetsDeleted.xsd
@@ -21,15 +21,15 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "user_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "jobcode_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "start": {
       "type": "string",

--- a/Intuit.TSheets/Model/Schemas/User.xsd
+++ b/Intuit.TSheets/Model/Schemas/User.xsd
@@ -42,7 +42,7 @@
   "properties": {
     "id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "first_name": {
       "type": "string"
@@ -58,14 +58,14 @@
     },
     "group_id": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "active": {
       "type": "boolean"
     },
     "employee_number": {
       "type": "integer",
-      "format": "int32"
+      "format": "int64"
     },
     "salaried": {
       "type": "boolean"
@@ -137,7 +137,7 @@
       "type": "array",
       "items": {
         "type": "integer",
-        "format": "int32"
+        "format": "int64"
       }
     },
     "require_password_change": {

--- a/Intuit.TSheets/Model/Timesheet.cs
+++ b/Intuit.TSheets/Model/Timesheet.cs
@@ -49,7 +49,7 @@ namespace Intuit.TSheets.Model
         /// <param name="userId">User id for the user that this timesheet belongs to.</param>
         /// <param name="jobcodeId">Jobcode id for the jobcode that this timesheet is recorded against.</param>
         /// <param name="start">Date/time that represents the start time of this timesheet.</param>
-        public Timesheet(int userId, int jobcodeId, DateTimeOffset start)
+        public Timesheet(long userId, long jobcodeId, DateTimeOffset start)
         {
             UserId = userId;
             JobcodeId = jobcodeId;
@@ -68,7 +68,7 @@ namespace Intuit.TSheets.Model
         /// <param name="jobcodeId">Jobcode id for the jobcode that this timesheet is recorded against.</param>
         /// <param name="start">Date/time that represents the start time of this timesheet.</param>
         /// <param name="end">Date/time that represents the end time of this timesheet.</param>
-        public Timesheet(int userId, int jobcodeId, DateTimeOffset start, DateTimeOffset end)
+        public Timesheet(long userId, long jobcodeId, DateTimeOffset start, DateTimeOffset end)
         {
             UserId = userId;
             JobcodeId = jobcodeId;
@@ -85,7 +85,7 @@ namespace Intuit.TSheets.Model
         /// <param name="jobcodeId">Id for the jobcode that this timesheet is recorded against.</param>
         /// <param name="duration">The total amount of time recorded for this timesheet.</param>
         /// <param name="date">The date on which time is to be recorded for this timesheet.</param>
-        public Timesheet(int userId, int jobcodeId, TimeSpan duration, DateTimeOffset date)
+        public Timesheet(long userId, long jobcodeId, TimeSpan duration, DateTimeOffset date)
         {
             UserId = userId;
             JobcodeId = jobcodeId;
@@ -99,19 +99,19 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the id for the user that this timesheet belongs to.
         /// </summary>
         [JsonProperty("user_id")]
-        public int? UserId { get; set; }
+        public long? UserId { get; set; }
 
         /// <summary>
         /// Gets or sets the id for the jobcode that this timesheet is recorded against.
         /// </summary>
         [JsonProperty("jobcode_id")]
-        public int? JobcodeId { get; set; }
+        public long? JobcodeId { get; set; }
 
         /// <summary>
         /// Gets the value indicating whether or not the timesheet is locked.
@@ -177,14 +177,14 @@ namespace Intuit.TSheets.Model
         /// Gets or sets the ids of files attached to this timesheet.
         /// </summary>
         [JsonProperty("attached_files")]
-        public IList<int> AttachedFiles { get; set; }
+        public IList<long> AttachedFiles { get; set; }
 
         /// <summary>
         /// Gets the user id for the user that initially created this timesheet.
         /// </summary>
         [NoSerializeOnWrite]
         [JsonProperty("created_by_user_id")]
-        public int? CreatedByUserId { get; internal set; }
+        public long? CreatedByUserId { get; internal set; }
 
         /// <summary>
         /// Gets or sets the total number of seconds recorded for this timesheet.

--- a/Intuit.TSheets/Model/TimesheetsDeleted.cs
+++ b/Intuit.TSheets/Model/TimesheetsDeleted.cs
@@ -38,19 +38,19 @@ namespace Intuit.TSheets.Model
         /// Gets the id of the timesheet.
         /// </summary>
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets the user id for the user that this timesheet belongs to.
         /// </summary>
         [JsonProperty("user_id")]
-        public int? UserId { get; internal set; }
+        public long? UserId { get; internal set; }
 
         /// <summary>
         /// Gets the id for the jobcode that this timesheet is recorded against.
         /// </summary>
         [JsonProperty("jobcode_id")]
-        public int? JobcodeId { get; internal set; }
+        public long? JobcodeId { get; internal set; }
 
         /// <summary>
         /// Gets the date/time that represents the start time of this timesheet.

--- a/Intuit.TSheets/Model/User.cs
+++ b/Intuit.TSheets/Model/User.cs
@@ -60,7 +60,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnCreate]
         [JsonProperty("id")]
-        public int Id { get; internal set; }
+        public long Id { get; internal set; }
 
         /// <summary>
         /// Gets or sets the first name of user.
@@ -90,7 +90,7 @@ namespace Intuit.TSheets.Model
         /// Gets or sets the id of the group this user belongs to.
         /// </summary>
         [JsonProperty("group_id")]
-        public int? GroupId { get; set; }
+        public long? GroupId { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether this user is active or archived.
@@ -102,7 +102,7 @@ namespace Intuit.TSheets.Model
         /// Gets or sets the employee number associated with this user.
         /// </summary>
         [JsonProperty("employee_number")]
-        public int? EmployeeNumber { get; set; }
+        public long? EmployeeNumber { get; set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether or not the user is salaried.
@@ -211,7 +211,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnWrite]
         [JsonProperty("pto_balances")]
-        public IReadOnlyDictionary<int, int> PtoBalances { get; internal set; }
+        public IReadOnlyDictionary<long, int> PtoBalances { get; internal set; }
 
         /// <summary>
         /// Gets or sets the latest date up to which this user has submitted timesheets.
@@ -232,7 +232,7 @@ namespace Intuit.TSheets.Model
         /// </summary>
         [NoSerializeOnWrite]
         [JsonProperty("manager_of_group_ids")]
-        public IReadOnlyList<int> ManagerOfGroups { get; internal set; }
+        public IReadOnlyList<long> ManagerOfGroups { get; internal set; }
 
         /// <summary>
         /// Gets or sets the value indicating whether or not a password change is required.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TSheets-V1-DotNET-SDK
 **Support:** [![Help](https://img.shields.io/badge/Support-TSheets%20Developer-blue.svg)](https://www.tsheets.com/contact-tsheets)<br/>
 **Documentation:** [![User Guide](https://img.shields.io/badge/User%20Guide-SDK%20Docs-blue.svg)](./Documentation/tsheets-sdk.md)<br/>
 **Continuous Integration:** [![Build Status](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)<br/>
-**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.4.0-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
+**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.4.1-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
 
 The TSheets .NET SDK provides class libraries for accessing the TSheets API quickly, easily, and with confidence.
 It supports .Net Standard 2.0, and .Net Framework 4.7.2.


### PR DESCRIPTION
v1.4.1 BREAKING CHANGE - Fixing issue #22 (Geolocation.Id is more than Int32 max).  All entity ID's & ID references are now a long data type.  Even though Geolocation is the only type for which id's have now exceeded Int32.Max (and for the foreseeable future), all types must be updated since there is an widespread abstraction on the ID property.  All clients that use this version will need to be updated accordingly.

### What Changed?
All entity ID's & ID references are now a long data type.

### Why?
Serialization of Geolocation entities fails because the id values exceed Int32.Max

### What else might be impacted?
All clients will need to be updated.

## Checklist

- [ x] Documentation
- [x ] Unit Tests
- [ x] Added self to contributors
- [ x] Added SemVer label
- [x ] Ready to be merged