### PR TITLE
BUGFIX: Addressing issue #24 - fixing broken serialization of Project…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.4.2 (Fri. Aug 6th, 2021)
+
+#### Bugfix
+
+ - Addressing issue #24: Fixing broken serialization of `ProjectReport`.
+
 # v1.4.1 (Wed. Jul 14th, 2021)
 
 #### THIS IS A BREAKING CHANGE RELEASE

--- a/Intuit.TSheets.Examples/ExampleAppService.cs
+++ b/Intuit.TSheets.Examples/ExampleAppService.cs
@@ -123,6 +123,9 @@ namespace Intuit.TSheets.Examples
                 Console.WriteLine("Operation canceled.");
             }
 
+            // Get a project report
+            GetProjectReport(new List<long> { 20370911 }, DateTimeOffset.Now.AddDays(-14), DateTimeOffset.Now);
+
             // Cleanup everything that was added.
             Cleanup();
 
@@ -535,6 +538,19 @@ namespace Intuit.TSheets.Examples
                 "Retrieved {UserCount} user(s) and {JobcodeCount} jobcode(s).",
                 users.Count(),
                 jobcodes.Count());
+        }
+
+        /// <summary>
+        /// Retrieve project report for given jobcode id's over a date range.
+        /// </summary>
+        private ProjectReport GetProjectReport(List<long> jobcodeId, DateTimeOffset startDate, DateTimeOffset endDate)
+        {
+            var filter = new ProjectReportFilter { StartDate = startDate, EndDate = endDate, JobcodeIds = jobcodeId };
+
+            ProjectReport projectReport = this.apiClient.GetProjectReport(filter).Item1;
+
+            return projectReport;
+
         }
 
         /// <summary>

--- a/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
+++ b/Intuit.TSheets.Examples/Intuit.TSheets.Examples.csproj
@@ -13,8 +13,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
     <PackageReleaseNotes />
-    <AssemblyVersion>1.4.1.0</AssemblyVersion>
-    <Version>1.4.1</Version>
+    <AssemblyVersion>1.4.2.0</AssemblyVersion>
+    <Version>1.4.2</Version>
     <FileVersion>1.4.0.0</FileVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
+++ b/Intuit.TSheets.SchemaGen/Intuit.TSheets.SchemaGen.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <AssemblyVersion>1.4.1.0</AssemblyVersion>
-    <FileVersion>1.4.1.0</FileVersion>
-    <Version>1.4.1</Version>
+    <AssemblyVersion>1.4.2.0</AssemblyVersion>
+    <FileVersion>1.4.2.0</FileVersion>
+    <Version>1.4.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
+++ b/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
@@ -12,9 +12,9 @@
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <AssemblyVersion>1.4.1.0</AssemblyVersion>
-    <FileVersion>1.4.1.0</FileVersion>
-    <Version>1.4.1</Version>
+    <AssemblyVersion>1.4.2.0</AssemblyVersion>
+    <FileVersion>1.4.2.0</FileVersion>
+    <Version>1.4.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets.Tests/Unit/Client/Serialization/Converters/EnumerableToCsvConverterTests.cs
+++ b/Intuit.TSheets.Tests/Unit/Client/Serialization/Converters/EnumerableToCsvConverterTests.cs
@@ -29,9 +29,9 @@ namespace Intuit.TSheets.Tests.Unit.Client.Serialization.Converters
     public class EnumerableToCsvConverterTests
     {
         [TestMethod, TestCategory("Unit")]
-        public void EnumerableToCsvConverter_SerializesIntsToCsv()
+        public void EnumerableToCsvConverter_SerializesLongsToCsv()
         {
-            var testEntityFalse = new IntsToCsvConverterTestEntity { Ids = new[] { 1, 2, 3 } };
+            var testEntityFalse = new LongsToCsvConverterTestEntity { Ids = new long[] { 1, 2, 3 } };
 
             Assert.AreEqual("{\"Ids\":\"1,2,3\"}", JsonConvert.SerializeObject(testEntityFalse));
         }
@@ -45,10 +45,10 @@ namespace Intuit.TSheets.Tests.Unit.Client.Serialization.Converters
         }
 
         [TestMethod, TestCategory("Unit")]
-        public void EnumerableToCsvConverter_DeserializesCsvToInts()
+        public void EnumerableToCsvConverter_DeserializesCsvToLongs()
         {
-            var expected = new[] { 1, 2, 3 };
-            var testEntity = JsonConvert.DeserializeObject<IntsToCsvConverterTestEntity>("{\"Ids\":\"1,2,3\"}");
+            var expected = new long[] { 1, 2, 3 };
+            var testEntity = JsonConvert.DeserializeObject<LongsToCsvConverterTestEntity>("{\"Ids\":\"1,2,3\"}");
 
             Assert.IsTrue(expected.SequenceEqual(testEntity.Ids));
         }
@@ -63,10 +63,10 @@ namespace Intuit.TSheets.Tests.Unit.Client.Serialization.Converters
         }
     }
 
-    public class IntsToCsvConverterTestEntity
+    public class LongsToCsvConverterTestEntity
     {
         [JsonConverter(typeof(EnumerableToCsvConverter))]
-        public IList<int> Ids { get; set; }
+        public IList<long> Ids { get; set; }
     }
 
     public class StringsToCsvConverterTestEntity

--- a/Intuit.TSheets/Client/Serialization/Converters/EnumerableToCsvConverter.cs
+++ b/Intuit.TSheets/Client/Serialization/Converters/EnumerableToCsvConverter.cs
@@ -53,7 +53,7 @@ namespace Intuit.TSheets.Client.Serialization.Converters
         /// <param name="serializer">The calling serializer, <see cref="JsonSerializer"/></param> 
         /// <example>
         /// <![CDATA[
-        /// Given: "1,2,3", Return: new List<int>{ 1, 2, 3 }
+        /// Given: "1,2,3", Return: new List<long>{ 1, 2, 3 }
         /// ]]>
         /// </example>
         /// <returns>The generic list of values</returns>
@@ -69,9 +69,9 @@ namespace Intuit.TSheets.Client.Serialization.Converters
             // Split the values and return as a list of ints if possible, else as a list of strings.
             List<string> values = csv.Split(',').Select(p => p.Trim()).ToList();
 
-            if (values.All(v => int.TryParse(v, out _)))
+            if (values.All(v => long.TryParse(v, out _)))
             {
-                return values.Select(v => int.Parse(v)).ToList();
+                return values.Select(v => long.Parse(v)).ToList();
             }
 
             return values;
@@ -85,7 +85,7 @@ namespace Intuit.TSheets.Client.Serialization.Converters
         /// <param name="serializer">The calling serializer, <see cref="JsonSerializer"/></param>
         /// <example>
         /// <![CDATA[
-        /// Given: List<int>{ 1, 2, 3 }, Return: "1,2,3"
+        /// Given: List<long>{ 1, 2, 3 }, Return: "1,2,3"
         /// ]]>
         /// </example>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/Intuit.TSheets/Intuit.TSheets.csproj
+++ b/Intuit.TSheets/Intuit.TSheets.csproj
@@ -9,15 +9,14 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Intuit</Authors>
     <PackageProjectUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</PackageProjectUrl>
-    <AssemblyVersion>1.4.1.0</AssemblyVersion>
-    <FileVersion>1.4.1.0</FileVersion>
+    <AssemblyVersion>1.4.2.0</AssemblyVersion>
+    <FileVersion>1.4.2.0</FileVersion>
     <RepositoryUrl>https://github.com/intuit/TSheets-V1-DotNET-SDK</RepositoryUrl>
     <PackageIcon>Circle_T_web128px.png</PackageIcon>
     <RepositoryType>Git</RepositoryType>
-    <PackageReleaseNotes>THIS IS A BREAKING CHANGE RELEASE:
-All entity and entity reference ID's are now data type _long_.</PackageReleaseNotes>
+    <PackageReleaseNotes>BUGFIX: Fixing serialization issue with ProjectReport.</PackageReleaseNotes>
     <PackageTags>tsheets, sdk, quickbooks, time, tracking, api-client, time-tracking, payroll-management</PackageTags>
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Intuit.TSheets/Model/ProjectReportFilters.cs
+++ b/Intuit.TSheets/Model/ProjectReportFilters.cs
@@ -25,6 +25,8 @@ namespace Intuit.TSheets.Model
     using Intuit.TSheets.Model.Enums;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
+    using NJsonSchema;
+    using NJsonSchema.Annotations;
 
     /// <summary>
     /// The filters used to generate the report.
@@ -39,7 +41,7 @@ namespace Intuit.TSheets.Model
         /// Only time for these users will be included.
         /// </remarks>
         [JsonProperty("user_ids")]
-        public IReadOnlyList<long> UserIds { get; internal set; }
+        public IReadOnlyList<string> UserIds { get; internal set; }
 
         /// <summary>
         /// Gets filter for the ids for <see cref="Group"/> objects to be included in the report.
@@ -76,6 +78,8 @@ namespace Intuit.TSheets.Model
         /// <remarks>
         /// Only time for these jobcodes will be included.
         /// </remarks>
+        [JsonConverter(typeof(EnumerableToCsvConverter))]
+        [JsonSchema(JsonObjectType.String)]
         [JsonProperty("jobcode_ids")]
         public IReadOnlyList<long> JobcodeIds { get; internal set; }
 

--- a/Intuit.TSheets/Model/ProjectReportTotals.cs
+++ b/Intuit.TSheets/Model/ProjectReportTotals.cs
@@ -20,6 +20,7 @@
 namespace Intuit.TSheets.Model
 {
     using System.Collections.Generic;
+    using Intuit.TSheets.Client.Serialization.Converters;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -31,24 +32,28 @@ namespace Intuit.TSheets.Model
         /// <summary>
         /// Gets User Report Totals
         /// </summary>
+        [JsonConverter(typeof(EmptyArrayObjectConverter))]
         [JsonProperty("users")]
         public IReadOnlyDictionary<long, float> Users { get; internal set; }
 
         /// <summary>
         /// Gets Group Report Totals
         /// </summary>
+        [JsonConverter(typeof(EmptyArrayObjectConverter))]
         [JsonProperty("groups")]
         public IReadOnlyDictionary<long, float> Groups { get; internal set; }
 
         /// <summary>
         /// Gets Jobcode Report Totals
         /// </summary>
+        [JsonConverter(typeof(EmptyArrayObjectConverter))]
         [JsonProperty("jobcodes")]
         public IReadOnlyDictionary<long, float> Jobcodes { get; internal set; }
 
         /// <summary>
         /// Gets Custom Field Report Totals
         /// </summary>
+        [JsonConverter(typeof(EmptyArrayObjectConverter))]
         [JsonProperty("customfields")]
         public IReadOnlyDictionary<long, IReadOnlyDictionary<long, float>> CustomFields { get; internal set; }
     }

--- a/Intuit.TSheets/Model/Schemas/ProjectReport.xsd
+++ b/Intuit.TSheets/Model/Schemas/ProjectReport.xsd
@@ -44,8 +44,7 @@
         "user_ids": {
           "type": "array",
           "items": {
-            "type": "integer",
-            "format": "int64"
+            "type": "string"
           }
         },
         "group_ids": {
@@ -64,11 +63,7 @@
           "format": "date-time"
         },
         "jobcode_ids": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
+          "type": "string"
         },
         "customfielditems": {
           "type": "object",

--- a/Intuit.TSheets/Model/Schemas/ProjectReportData.xsd
+++ b/Intuit.TSheets/Model/Schemas/ProjectReportData.xsd
@@ -32,8 +32,7 @@
         "user_ids": {
           "type": "array",
           "items": {
-            "type": "integer",
-            "format": "int64"
+            "type": "string"
           }
         },
         "group_ids": {
@@ -52,11 +51,7 @@
           "format": "date-time"
         },
         "jobcode_ids": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
+          "type": "string"
         },
         "customfielditems": {
           "type": "object",

--- a/Intuit.TSheets/Model/Schemas/ProjectReportFilters.xsd
+++ b/Intuit.TSheets/Model/Schemas/ProjectReportFilters.xsd
@@ -16,8 +16,7 @@
     "user_ids": {
       "type": "array",
       "items": {
-        "type": "integer",
-        "format": "int64"
+        "type": "string"
       }
     },
     "group_ids": {
@@ -36,11 +35,7 @@
       "format": "date-time"
     },
     "jobcode_ids": {
-      "type": "array",
-      "items": {
-        "type": "integer",
-        "format": "int64"
-      }
+      "type": "string"
     },
     "customfielditems": {
       "type": "object",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TSheets-V1-DotNET-SDK
 **Support:** [![Help](https://img.shields.io/badge/Support-TSheets%20Developer-blue.svg)](https://www.tsheets.com/contact-tsheets)<br/>
 **Documentation:** [![User Guide](https://img.shields.io/badge/User%20Guide-SDK%20Docs-blue.svg)](./Documentation/tsheets-sdk.md)<br/>
 **Continuous Integration:** [![Build Status](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)](https://travis-ci.com/intuit/TSheets-V1-DotNET-SDK.svg?token=HSEoRBBbbnL3x2dQy3Rm&branch=master)<br/>
-**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.4.1-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
+**Binaries:** [![Nuget](https://img.shields.io/badge/Nuget-1.4.2-blue.svg)](https://www.nuget.org/packages/Intuit.TSheets/)<br/>
 
 The TSheets .NET SDK provides class libraries for accessing the TSheets API quickly, easily, and with confidence.
 It supports .Net Standard 2.0, and .Net Framework 4.7.2.


### PR DESCRIPTION
…Report.

### What Changed?
 - Fixed a regression with `EnumerableToCsvConverter` to use long instead of int
 - Apply the above custom converter attribute to properties of the ProjectReport entity to fix broken serialization.
 
### Why?
 - responding to issue #24

### What else might be impacted?

## Checklist

- [x ] Documentation
- [x ] Unit Tests
- [x ] Added self to contributors
- [x ] Added SemVer label
- [x ] Ready to be merged