### PR TITLE
Bugfix: fixing deserialization of ProjectReportTotals, not using Empt…

### DIFF
--- a/Intuit.TSheets/Model/ProjectReportTotals.cs
+++ b/Intuit.TSheets/Model/ProjectReportTotals.cs
@@ -32,28 +32,24 @@ namespace Intuit.TSheets.Model
         /// <summary>
         /// Gets User Report Totals
         /// </summary>
-        [JsonConverter(typeof(EmptyArrayObjectConverter))]
         [JsonProperty("users")]
         public IReadOnlyDictionary<long, float> Users { get; internal set; }
 
         /// <summary>
         /// Gets Group Report Totals
         /// </summary>
-        [JsonConverter(typeof(EmptyArrayObjectConverter))]
         [JsonProperty("groups")]
         public IReadOnlyDictionary<long, float> Groups { get; internal set; }
 
         /// <summary>
         /// Gets Jobcode Report Totals
         /// </summary>
-        [JsonConverter(typeof(EmptyArrayObjectConverter))]
         [JsonProperty("jobcodes")]
         public IReadOnlyDictionary<long, float> Jobcodes { get; internal set; }
 
         /// <summary>
         /// Gets Custom Field Report Totals
         /// </summary>
-        [JsonConverter(typeof(EmptyArrayObjectConverter))]
         [JsonProperty("customfields")]
         public IReadOnlyDictionary<long, IReadOnlyDictionary<long, float>> CustomFields { get; internal set; }
     }


### PR DESCRIPTION
…yArrayObjectConverter.

### What Changed?
The TSheets API returns an empty JSON *array* to indicate no results found, when in actuality the response
should be an empty *object*.  This causes deserialization to fail since JsonConvert doesn't know how to 
handle it.  For some objects the SDK uses a custom converter, but this isn't working for the ProjectReportTotals
object.  Instead, we'll fix the JSON response text directly, just prior to deserialization.

### Why?
see above

### What else might be impacted?
n/a

## Checklist

- [x ] Documentation
- [x ] Unit Tests
- [x ] Added self to contributors
- [x ] Added SemVer label
- [x ] Ready to be merged