### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
+++ b/Intuit.TSheets.Tests/Intuit.TSheets.Tests.csproj
@@ -19,14 +19,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.1" />
+    <PackageReference Include="Moq" Version="4.14.6" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="NJsonSchema" Version="10.0.22" />
+    <PackageReference Include="NJsonSchema" Version="10.0.24" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@dustinsweet, I found an issue in the Intuit.TSheets.Tests.csproj:

Packages AutoFixture v4.11.0, Microsoft.Extensions.Logging v2.2.0, Microsoft.NET.Test.Sdk v15.8.0, Moq v4.12.0, MSTest.TestAdapter v1.3.2, MSTest.TestFramework v1.3.2 and NJsonSchema v10.0.22 transitively introduce 103 dependencies into TSheets-V1-DotNET-SDK’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/TSheets-V1-DotNET-SDK.html)), while AutoFixture v4.17.0, Microsoft.Extensions.Logging v5.0.0, Microsoft.NET.Test.Sdk v15.9.1, Moq v4.14.6, MSTest.TestAdapter v1.4.0, MSTest.TestFramework v1.4.0 and NJsonSchema v10.0.24 can only introduce 74 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/TSheets-V1-DotNET-SDK_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose